### PR TITLE
feat(group): drop default ledger and mark current ledger in management page

### DIFF
--- a/my-app/src/app/DashboardSection.tsx
+++ b/my-app/src/app/DashboardSection.tsx
@@ -5,6 +5,7 @@ import Overview from '@/app/transactions/Overview';
 import { QuickNavigationCards } from '@/components/QuickNavigationCards';
 import { RecentTransactionsList } from '@/components/RecentTransactionsList';
 import { DashboardSkeleton } from '@/components/skeletons/DashboardSkeleton';
+import { NoGroupEmptyState } from '@/components/NoGroupEmptyState';
 import { useBudgetCtx } from '@/context/BudgetProvider';
 import { useGroupCtx } from '@/context/GroupProvider';
 import { useGetSpendingCtx } from '@/context/SpendingProvider';
@@ -87,6 +88,10 @@ export const DashboardSection = ({ isMobile }: { isMobile: boolean }) => {
   // Only show the skeleton when we genuinely have nothing to render yet.
   if (!hasEverLoaded && data.length === 0) {
     return <DashboardSkeleton />;
+  }
+
+  if (!currentGroup) {
+    return <NoGroupEmptyState>{null}</NoGroupEmptyState>;
   }
 
   return (

--- a/my-app/src/app/analysis/ChartBlock.tsx
+++ b/my-app/src/app/analysis/ChartBlock.tsx
@@ -3,6 +3,7 @@
 import { ChartContainer } from '@/app/analysis/ChartContainer';
 import { YearMonthFilter } from '@/app/analysis/YearMonthFilter';
 import { AnalysisSkeleton } from '@/components/skeletons/AnalysisSkeleton';
+import { NoGroupEmptyState } from '@/components/NoGroupEmptyState';
 import { useBudgetCtx } from '@/context/BudgetProvider';
 import { useGroupCtx } from '@/context/GroupProvider';
 import { useGetSpendingCtx } from '@/context/SpendingProvider';
@@ -163,6 +164,10 @@ export const ChartBlock = () => {
   // Only show the skeleton when we genuinely have nothing to render yet.
   if (!hasEverLoaded && data.length === 0) {
     return <AnalysisSkeleton />;
+  }
+
+  if (!currentGroup) {
+    return <NoGroupEmptyState>{null}</NoGroupEmptyState>;
   }
 
   return (

--- a/my-app/src/app/budget/page.tsx
+++ b/my-app/src/app/budget/page.tsx
@@ -6,6 +6,7 @@ import { MonthlyBudgetSection } from '@/app/budget/MonthlyBudgetSection';
 import { MonthlyBudgetBlocks } from '@/app/budget/MonthlyBudgetBlocks';
 import { RecurringBudgetItems } from '@/app/budget/RecurringBudgetItems';
 import { BudgetSkeleton } from '@/components/skeletons/BudgetSkeleton';
+import { NoGroupEmptyState } from '@/components/NoGroupEmptyState';
 import { useBudgetCtx } from '@/context/BudgetProvider';
 import { useGroupCtx } from '@/context/GroupProvider';
 import { useGetSpendingCtx } from '@/context/SpendingProvider';
@@ -35,11 +36,7 @@ function BudgetContent() {
   const yearlySpending = useMemo(() => spendingData, [spendingData]);
 
   if (!currentGroup) {
-    return (
-      <div className="flex w-full flex-1 items-center justify-center">
-        <p className="text-gray-300">請先選擇一個帳本</p>
-      </div>
-    );
+    return <NoGroupEmptyState>{null}</NoGroupEmptyState>;
   }
 
   // Only show the skeleton when we genuinely have nothing to render yet.

--- a/my-app/src/app/group/Dashboard.tsx
+++ b/my-app/src/app/group/Dashboard.tsx
@@ -20,7 +20,14 @@ import QRCode from 'react-qr-code';
 
 export const Dashboard = () => {
   const { config: userData, syncUser } = useUserConfigCtx();
-  const { groups, syncGroup, setter: setGroups, loading } = useGroupCtx();
+  const {
+    groups,
+    syncGroup,
+    setter: setGroups,
+    loading,
+    currentGroup,
+    setCurrentGroup,
+  } = useGroupCtx();
 
   const refresh = useCallback(() => {
     if (userData) {
@@ -56,9 +63,21 @@ export const Dashboard = () => {
         </button>
       </div>
       <div className="flex w-full flex-col gap-4 sm:flex-row sm:flex-wrap">
-        {groups.map((group) => (
-          <GroupCard key={group.account_id} group={group} refresh={refresh} />
-        ))}
+        {groups.length === 0 ? (
+          <div className="w-full rounded-xl border border-dashed border-gray-600 p-8 text-center text-sm text-gray-400">
+            尚未建立任何帳本，點上方「建立新帳本」開始記帳。
+          </div>
+        ) : (
+          groups.map((group) => (
+            <GroupCard
+              key={group.account_id}
+              group={group}
+              refresh={refresh}
+              isCurrent={group.account_id === currentGroup?.account_id}
+              onSelect={() => setCurrentGroup(group)}
+            />
+          ))
+        )}
       </div>
     </div>
   );
@@ -67,9 +86,13 @@ export const Dashboard = () => {
 const GroupCard = ({
   group,
   refresh,
+  isCurrent,
+  onSelect,
 }: {
   group: Group;
   refresh: () => void;
+  isCurrent: boolean;
+  onSelect: () => void;
 }) => {
   const { config: userData } = useUserConfigCtx();
   const { groups, setter: setGroups } = useGroupCtx();
@@ -219,17 +242,38 @@ const GroupCard = ({
   };
 
   return (
-    <div className="card relative grid w-full max-w-87.5 grid-cols-12 gap-4 transition-all duration-200 hover:shadow-[0_0_20px_rgba(6,182,212,0.2)]">
+    <div
+      className={`card relative grid w-full max-w-87.5 grid-cols-12 gap-4 transition-all duration-200 hover:shadow-[0_0_20px_rgba(6,182,212,0.2)] ${
+        isCurrent
+          ? 'ring-primary-400 shadow-[0_0_20px_rgba(6,182,212,0.25)] ring-2'
+          : ''
+      }`}
+    >
       <div
         className={`absolute top-0 right-0 bottom-0 left-0 animate-pulse rounded-xl border border-solid border-transparent bg-gray-500/50 ${loading ? 'visible' : 'invisible'}`}
       ></div>
       <div className="col-span-10 flex flex-col justify-between gap-2">
-        <h3
-          className="overflow-hidden text-base font-bold text-ellipsis whitespace-nowrap text-gray-100 sm:text-lg"
-          style={{ fontFamily: 'var(--font-heading)' }}
-        >
-          {group.name}
-        </h3>
+        <div className="flex items-center gap-2">
+          <h3
+            className="overflow-hidden text-base font-bold text-ellipsis whitespace-nowrap text-gray-100 sm:text-lg"
+            style={{ fontFamily: 'var(--font-heading)' }}
+          >
+            {group.name}
+          </h3>
+          {isCurrent ? (
+            <span className="bg-primary-500/20 text-primary-300 ring-primary-500/40 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ring-1 ring-inset">
+              使用中
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={onSelect}
+              className="text-primary-400 hover:text-primary-300 shrink-0 text-[10px] font-semibold underline transition-colors"
+            >
+              切換為當前帳本
+            </button>
+          )}
+        </div>
         <div className="flex flex-wrap items-center gap-2">
           <span className="text-sm text-gray-400">成員:</span>
           {loadingMembers ? (

--- a/my-app/src/app/transactions/SpendingInfoSection.tsx
+++ b/my-app/src/app/transactions/SpendingInfoSection.tsx
@@ -5,6 +5,7 @@ import { YearMonthFilter } from '@/app/analysis/YearMonthFilter';
 import { SearchIcon } from '@/components/icons/SearchIcon';
 import { Select } from '@/components/Select';
 import { TransactionsSkeleton } from '@/components/skeletons/TransactionsSkeleton';
+import { NoGroupEmptyState } from '@/components/NoGroupEmptyState';
 import { useGroupCtx } from '@/context/GroupProvider';
 import { useGetSpendingCtx } from '@/context/SpendingProvider';
 import { useScrollToTop } from '@/hooks/useScrollToTop';
@@ -95,6 +96,10 @@ export const SpendingInfoSection = () => {
   // Only show the skeleton when we genuinely have nothing to render yet.
   if (!hasEverLoaded && data.length === 0) {
     return <TransactionsSkeleton />;
+  }
+
+  if (!currentGroup) {
+    return <NoGroupEmptyState>{null}</NoGroupEmptyState>;
   }
 
   return (

--- a/my-app/src/components/NoGroupEmptyState.tsx
+++ b/my-app/src/components/NoGroupEmptyState.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useGroupCtx } from '@/context/GroupProvider';
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+};
+
+export const NoGroupEmptyState = ({ children }: Props) => {
+  const { groups, hasEverLoaded, currentGroup } = useGroupCtx();
+
+  if (hasEverLoaded && groups.length === 0) {
+    return (
+      <div className="flex w-full flex-1 items-center justify-center p-6">
+        <div className="flex max-w-sm flex-col items-center gap-3 rounded-xl border border-dashed border-gray-600 p-6 text-center">
+          <p className="text-base font-semibold text-gray-100">
+            尚未建立任何帳本
+          </p>
+          <p className="text-sm text-gray-400">
+            建立第一本帳本後，即可開始記帳、規劃預算與檢視分析。
+          </p>
+          <Link
+            href="/group"
+            className="btn-primary mt-1 inline-flex min-h-11 items-center text-sm"
+          >
+            前往建立帳本
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (hasEverLoaded && !currentGroup) {
+    return (
+      <div className="flex w-full flex-1 items-center justify-center p-6">
+        <p className="text-sm text-gray-300">請先選擇一個帳本</p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+};

--- a/my-app/src/hooks/usePrepareData.ts
+++ b/my-app/src/hooks/usePrepareData.ts
@@ -4,7 +4,6 @@ import { useFavoriteCategoriesCtx } from '@/context/FavoriteCategoriesProvider';
 import { useGroupCtx } from '@/context/GroupProvider';
 import { useGetSpendingCtx } from '@/context/SpendingProvider';
 import { useUserConfigCtx } from '@/context/UserConfigProvider';
-import { createGroup } from '@/services/groupServices';
 import { getStartEndOfMonth } from '@/utils/getStartEndOfMonth';
 import { getCookie } from '@/utils/handleCookie';
 import { useSession } from 'next-auth/react';
@@ -16,8 +15,6 @@ export const usePrepareData = () => {
     groups,
     setCurrentGroup,
     currentGroup,
-    setter: setGroups,
-    hasEverLoaded: groupsLoaded,
   } = useGroupCtx();
   const { config: userData, syncUser } = useUserConfigCtx();
   const { syncData } = useGetSpendingCtx();
@@ -62,27 +59,6 @@ export const usePrepareData = () => {
       setCurrentGroup(defaultGroup);
     }
   }, [groups, setCurrentGroup, currentGroup]);
-
-  // Create default group if user has none.
-  useEffect(() => {
-    if (groupsLoaded && groups.length === 0 && effectiveUserId && userData) {
-      const newGroup: Group = {
-        account_id: Date.now(),
-        name: `${userData.name} 的個人帳本`,
-        owner_id: effectiveUserId,
-        members: [effectiveUserId],
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-      };
-
-      createGroup(newGroup)
-        .then(() => setGroups([newGroup], effectiveUserId))
-        .catch((err) => {
-          console.error('[usePrepareData] Error creating default group:', err);
-          setGroups([newGroup], effectiveUserId);
-        });
-    }
-  }, [groupsLoaded, groups.length, effectiveUserId, userData, setGroups]);
 
   // Sync current month spending whenever currentGroup changes.
   useEffect(() => {


### PR DESCRIPTION
## Summary
- 移除新用戶 / 空帳本狀態自動建立 `xxx 的個人帳本` 的行為，改由使用者自行在 `/group` 建立第一本帳本。
- 帳本管理頁為當前帳本加上 `ring` 高亮 + 「使用中」badge；非當前帳本顯示「切換為當前帳本」連結，解決名稱重複時無法區分的問題。
- 新增 `NoGroupEmptyState` 共用元件，套用至 Dashboard / Transactions / Analysis / Budget — 當沒有任何帳本時引導前往建立，避免依賴 `currentGroup` 的頁面渲染在 undefined 狀態。

## Test plan
- [ ] 新註冊 / 帳本清空的帳號登入後，不會自動產生個人帳本；Dashboard、Transactions、Analysis、Budget 顯示「尚未建立任何帳本」的空狀態 + 跳轉 `/group` 的 CTA。
- [ ] 在 `/group` 建立帳本後，回到首頁等頁面可正常記帳與檢視。
- [ ] 建立兩本同名帳本，在帳本管理頁可由 ring + 「使用中」badge 辨識當前帳本；點擊另一本的「切換為當前帳本」可正確切換並更新 cookie / cache。
- [ ] 在帳本管理頁切換當前帳本後，Transactions / Budget 的資料隨之刷新到對應帳本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)