### PR TITLE
Restyle UI with Apple-style light design system per DESIGN.md

### DIFF
--- a/my-app/src/app/analysis/BudgetCostTable.tsx
+++ b/my-app/src/app/analysis/BudgetCostTable.tsx
@@ -44,8 +44,8 @@ const BudgetCostTable = (props: Props) => {
   return (
     <div className="flex w-full flex-col gap-4">
       {/* Overall Summary */}
-      <div className="overflow-hidden rounded-lg border border-gray-600 bg-gray-800/90 shadow-sm backdrop-blur-sm">
-        <div className="bg-primary-500/20 border-b border-gray-600 px-4 py-3">
+      <div className="overflow-hidden rounded-lg border border-gray-700 bg-gray-950/90 shadow-sm backdrop-blur-sm">
+        <div className="bg-primary-500/20 border-b border-gray-700 px-4 py-3">
           <h3 className="text-sm font-bold text-gray-200">預算總覽</h3>
         </div>
         <div className="divide-y divide-gray-700">
@@ -60,7 +60,7 @@ const BudgetCostTable = (props: Props) => {
             <span
               className={`text-base font-semibold ${
                 totalSpent > totalBudgeted
-                  ? 'text-secondary-400'
+                  ? 'text-[var(--color-expense)]'
                   : 'text-gray-200'
               }`}
             >
@@ -72,7 +72,7 @@ const BudgetCostTable = (props: Props) => {
             <span
               className={`text-base font-semibold ${
                 totalSpent > totalBudgeted
-                  ? 'text-secondary-400'
+                  ? 'text-[var(--color-expense)]'
                   : 'text-income-400'
               }`}
             >
@@ -83,8 +83,8 @@ const BudgetCostTable = (props: Props) => {
       </div>
 
       {/* Spending Breakdown */}
-      <div className="overflow-hidden rounded-lg border border-gray-600 bg-gray-800/90 shadow-sm backdrop-blur-sm">
-        <div className="border-b border-gray-600 bg-orange-500/20 px-4 py-3">
+      <div className="overflow-hidden rounded-lg border border-gray-700 bg-gray-950/90 shadow-sm backdrop-blur-sm">
+        <div className="border-b border-gray-700 bg-orange-500/20 px-4 py-3">
           <h3 className="text-sm font-bold text-gray-200">支出結構分析</h3>
         </div>
         <div className="divide-y divide-gray-700">
@@ -115,8 +115,8 @@ const BudgetCostTable = (props: Props) => {
 
       {/* Category Breakdown */}
       {categoryBreakdown.length > 0 && (
-        <div className="overflow-hidden rounded-lg border border-gray-600 bg-gray-800/90 shadow-sm backdrop-blur-sm">
-          <div className="bg-accent-500/20 border-b border-gray-600 px-4 py-3">
+        <div className="overflow-hidden rounded-lg border border-gray-700 bg-gray-950/90 shadow-sm backdrop-blur-sm">
+          <div className="border-b border-gray-700 bg-gray-900 px-4 py-3">
             <h3 className="text-sm font-bold text-gray-200">
               各類別預算使用情況
             </h3>
@@ -124,7 +124,7 @@ const BudgetCostTable = (props: Props) => {
           <div className="max-h-80 overflow-auto">
             <table className="w-full text-sm">
               <thead className="sticky top-0 bg-gray-800/95 backdrop-blur-sm">
-                <tr className="border-b border-gray-600">
+                <tr className="border-b border-gray-700">
                   <th className="px-4 py-2 text-left font-semibold text-gray-300">
                     類別
                   </th>
@@ -155,7 +155,9 @@ const BudgetCostTable = (props: Props) => {
                       </td>
                       <td
                         className={`px-4 py-2 text-right font-semibold ${
-                          isOver ? 'text-secondary-400' : 'text-gray-300'
+                          isOver
+                            ? 'text-[var(--color-expense)]'
+                            : 'text-gray-300'
                         }`}
                       >
                         ${normalizeNumber(item.spent)}

--- a/my-app/src/app/analysis/ChartContainer.tsx
+++ b/my-app/src/app/analysis/ChartContainer.tsx
@@ -8,14 +8,13 @@ export const ChartContainer = ({
   children: ReactNode;
 }) => {
   return (
-    <div className="card relative z-10 flex w-full flex-col items-center transition-all duration-200 hover:shadow-[0_0_20px_rgba(6,182,212,0.2)]">
+    <div className="card relative z-10 flex w-full flex-col items-center transition-all duration-200">
       <div className="mb-4 w-full">
         <h2
-          className="relative inline-block text-xl font-bold text-gray-100 select-none"
+          className="relative inline-block text-xl font-semibold text-gray-100 select-none"
           style={{ fontFamily: 'var(--font-heading)' }}
         >
           {title}
-          <span className="from-primary-500 to-accent-500 absolute -bottom-1 left-0 h-1 w-1/2 rounded-full bg-linear-to-r shadow-[0_0_8px_rgba(6,182,212,0.5)]"></span>
         </h2>
       </div>
       {children}

--- a/my-app/src/app/analysis/CostTable.tsx
+++ b/my-app/src/app/analysis/CostTable.tsx
@@ -5,7 +5,7 @@ export const CostTable = ({
   total,
   list,
   options = {
-    headerStyle: 'bg-gray-200',
+    headerStyle: 'bg-gray-700',
   },
 }: {
   title: string;
@@ -21,13 +21,13 @@ export const CostTable = ({
       <table className="w-full border-collapse text-sm">
         <thead>
           <tr className={options.headerStyle}>
-            <th className="border border-solid border-gray-300 border-r-transparent px-2 py-1 text-center">
+            <th className="border border-solid border-gray-700 border-r-transparent px-2 py-1 text-center">
               類型
             </th>
-            <th className="border border-solid border-gray-300 border-r-transparent px-2 py-1 text-right">
+            <th className="border border-solid border-gray-700 border-r-transparent px-2 py-1 text-right">
               比例 (%)
             </th>
-            <th className="border border-solid border-gray-300 px-2 py-1 text-right">
+            <th className="border border-solid border-gray-700 px-2 py-1 text-right">
               金額 (NTD)
             </th>
           </tr>
@@ -38,16 +38,16 @@ export const CostTable = ({
               key={`income-${item.name}`}
               className={item.value === 0 ? 'text-gray-300' : ''}
             >
-              <td className="col-span-1 border border-solid border-gray-300 p-2 text-center">
+              <td className="col-span-1 border border-solid border-gray-700 p-2 text-center">
                 {item.name}
               </td>
-              <td className="col-span-1 border border-solid border-gray-300 p-2 text-end">
+              <td className="col-span-1 border border-solid border-gray-700 p-2 text-end">
                 {item.value === 0
                   ? 0
                   : (Math.round((item.value / total) * 100) || 0).toFixed(0)}
                 %
               </td>
-              <td className="col-span-2 border border-solid border-gray-300 p-2 text-end">
+              <td className="col-span-2 border border-solid border-gray-700 p-2 text-end">
                 ${normalizeNumber(item.value)}
               </td>
             </tr>

--- a/my-app/src/app/analysis/YearMonthFilter.tsx
+++ b/my-app/src/app/analysis/YearMonthFilter.tsx
@@ -71,7 +71,7 @@ export const YearMonthFilter = (props: Props) => {
 
   return (
     <div className={`relative w-full md:max-w-80 ${className}`}>
-      <div className="hover:border-primary-400 flex w-full items-center gap-1.5 overflow-hidden rounded-xl border border-gray-600 bg-gray-800/90 shadow-sm backdrop-blur-sm transition-all hover:shadow-[0_0_15px_rgba(6,182,212,0.2)]">
+      <div className="hover:border-primary-400 flex w-full items-center gap-1.5 overflow-hidden rounded-xl border border-gray-600 bg-gray-950/90 backdrop-blur-sm transition-all">
         <button
           type="button"
           onClick={handlePreviousMonth}
@@ -105,7 +105,7 @@ export const YearMonthFilter = (props: Props) => {
             </span>
           </div>
           {isCurrentMonth() && (
-            <span className="bg-primary-500 ml-1 size-2 rounded-full shadow-[0_0_8px_rgba(6,182,212,0.6)]"></span>
+            <span className="bg-primary-500 ml-1 size-2 rounded-full"></span>
           )}
         </button>
 
@@ -122,29 +122,29 @@ export const YearMonthFilter = (props: Props) => {
       {/* Dropdown panel */}
       <div
         ref={ref}
-        className={`absolute top-full left-1/2 z-20 mt-2 w-80 overflow-hidden rounded-2xl border border-gray-600 bg-gray-800/95 shadow-xl backdrop-blur-sm transition-all ${
+        className={`absolute top-full left-1/2 z-20 mt-2 w-80 overflow-hidden rounded-2xl border border-gray-700 bg-gray-950/95 shadow-lg backdrop-blur-sm transition-all ${
           open
             ? `${styles.dropdownAnimation} visible opacity-100`
             : 'invisible translate-y-1 opacity-0'
         }`}
       >
         {/* Year selector */}
-        <div className="from-primary-500/20 to-accent-500/20 border-b border-gray-600 bg-linear-to-r px-4 py-3">
+        <div className="border-b border-gray-700 bg-gray-900 px-4 py-3">
           <div className="flex items-center justify-between">
             <button
               onClick={() => setYear((Number(year) - 1).toString())}
-              className="text-primary-400 flex items-center justify-center rounded-lg p-1.5 transition-all hover:bg-gray-700/60 hover:shadow-[0_0_10px_rgba(6,182,212,0.2)] active:bg-gray-700"
+              className="text-primary-500 flex items-center justify-center rounded-lg p-1.5 transition-all hover:bg-gray-800 active:bg-gray-700/60"
             >
               <BiChevronLeft className="size-5" />
             </button>
 
-            <span className="text-primary-300 text-xl font-bold">
+            <span className="text-xl font-semibold text-gray-100">
               {year} 年
             </span>
 
             <button
               onClick={() => setYear((Number(year) + 1).toString())}
-              className="text-primary-400 flex items-center justify-center rounded-lg p-1.5 transition-all hover:bg-gray-700/60 hover:shadow-[0_0_10px_rgba(6,182,212,0.2)] active:bg-gray-700"
+              className="text-primary-500 flex items-center justify-center rounded-lg p-1.5 transition-all hover:bg-gray-800 active:bg-gray-700/60"
             >
               <BiChevronRight className="size-5" />
             </button>
@@ -168,17 +168,17 @@ export const YearMonthFilter = (props: Props) => {
                     setMonth(MONTH_LABEL[monthLabel]);
                     setOpen(false);
                   }}
-                  className={`relative rounded-xl px-3 py-2.5 text-sm font-semibold transition-all ${styles.monthButton} ${
+                  className={`relative rounded-full px-3 py-2.5 text-sm font-semibold transition-all ${styles.monthButton} ${
                     isSelected
-                      ? 'bg-primary-500 ring-primary-400 text-white shadow-[0_0_15px_rgba(6,182,212,0.5)] ring-2'
+                      ? 'bg-primary-500 text-white'
                       : isCurrentYearMonth
-                        ? 'bg-primary-500/20 text-primary-400 hover:bg-primary-500/30 hover:shadow-[0_0_10px_rgba(6,182,212,0.3)]'
-                        : 'hover:text-primary-400 text-gray-300 hover:bg-gray-700/70 hover:shadow-[0_0_8px_rgba(6,182,212,0.2)]'
+                        ? 'bg-primary-100 text-primary-500 hover:bg-primary-200/70'
+                        : 'hover:text-primary-500 text-gray-300 hover:bg-gray-800'
                   }`}
                 >
                   {monthLabel}
                   {isCurrentYearMonth && !isSelected && (
-                    <span className="bg-primary-500 absolute top-1 right-1 size-2 rounded-full shadow-[0_0_8px_rgba(6,182,212,0.6)]"></span>
+                    <span className="bg-primary-500 absolute top-1 right-1 size-2 rounded-full"></span>
                   )}
                 </button>
               );
@@ -187,12 +187,12 @@ export const YearMonthFilter = (props: Props) => {
         </div>
 
         {/* Quick actions */}
-        <div className="flex items-center justify-between border-t border-gray-600 bg-gray-700/50 px-4 py-3">
+        <div className="flex items-center justify-between border-t border-gray-700 bg-gray-900 px-4 py-3">
           <button
             onClick={() => {
               setYear((Number(year) - 1).toString());
             }}
-            className="hover:text-primary-400 text-sm font-medium text-gray-400 transition-colors"
+            className="hover:text-primary-500 text-sm text-gray-400 transition-colors"
           >
             去年同月
           </button>
@@ -204,7 +204,7 @@ export const YearMonthFilter = (props: Props) => {
               setYear(today.getFullYear().toString());
               setOpen(false);
             }}
-            className="from-primary-500 to-primary-600 shadow-warm hover:shadow-warm-lg rounded-xl bg-linear-to-r px-4 py-2 text-sm font-semibold text-white transition-all hover:brightness-110 active:brightness-100"
+            className="bg-primary-500 hover:bg-primary-400 rounded-full px-4 py-2 text-sm text-white transition-all active:scale-95"
           >
             回到本月
           </button>

--- a/my-app/src/app/budget/AnnualBudgetSection.tsx
+++ b/my-app/src/app/budget/AnnualBudgetSection.tsx
@@ -32,11 +32,11 @@ export const AnnualBudgetSection = ({ yearlySpending }: Props) => {
 
   return (
     <div
-      className="flex w-full flex-col gap-3 rounded-2xl border border-white/[0.06] bg-gray-800/80 p-5 shadow-md backdrop-blur-sm"
+      className="flex w-full flex-col gap-3 rounded-2xl border border-black/[0.08] bg-gray-950 p-5 backdrop-blur-sm"
       style={{ textWrap: 'pretty' }}
     >
       <span
-        className="text-[11px] font-semibold uppercase text-gray-400"
+        className="text-[11px] font-semibold text-gray-400 uppercase"
         style={{ letterSpacing: '0.12em' }}
       >
         年度預算
@@ -50,7 +50,7 @@ export const AnnualBudgetSection = ({ yearlySpending }: Props) => {
       >
         ${normalizeNumber(annualBudget)}
       </p>
-      <div className="h-1 w-full overflow-hidden rounded-full bg-white/[0.06]">
+      <div className="h-1 w-full overflow-hidden rounded-full bg-black/[0.06]">
         <div
           className="h-full rounded-full transition-all duration-300"
           style={{

--- a/my-app/src/app/budget/MonthlyBudgetBlocks.tsx
+++ b/my-app/src/app/budget/MonthlyBudgetBlocks.tsx
@@ -282,13 +282,13 @@ export const MonthlyBudgetBlocks = ({ yearlySpending }: Props) => {
             <Accordion
               key={month.value}
               defaultOpen={isCurrentMonth}
-              className="rounded-2xl border bg-gray-800/80 backdrop-blur-sm"
+              className="rounded-2xl border bg-gray-950/80 backdrop-blur-sm"
               style={{
                 borderColor: isOverBudget
-                  ? 'rgba(248,113,113,0.3)'
+                  ? 'rgba(227,0,0,0.3)'
                   : isCurrentMonth
-                    ? 'rgba(6,182,212,0.35)'
-                    : 'rgba(255,255,255,0.06)',
+                    ? 'rgba(0,102,204,0.35)'
+                    : 'rgba(0,0,0,0.08)',
               }}
               buttonProps={{ className: 'w-full px-4 py-3' }}
               summary={(isOpen) => (
@@ -356,7 +356,7 @@ export const MonthlyBudgetBlocks = ({ yearlySpending }: Props) => {
                 </div>
 
                 {monthTotal > 0 && (
-                  <div className="h-1 w-full overflow-hidden rounded-full bg-white/[0.06]">
+                  <div className="h-1 w-full overflow-hidden rounded-full bg-black/[0.06]">
                     <div
                       className="h-full rounded-full transition-all duration-300"
                       style={{
@@ -392,12 +392,12 @@ export const MonthlyBudgetBlocks = ({ yearlySpending }: Props) => {
                     monthItems.map((item) => (
                       <div
                         key={`${month.value}-${item.index}`}
-                        className="flex items-center justify-between rounded-xl border border-white/[0.06] bg-white/[0.02] px-3 py-2 transition-colors hover:bg-white/[0.04]"
+                        className="flex items-center justify-between rounded-xl border border-black/[0.08] bg-black/[0.02] px-3 py-2 transition-colors hover:bg-black/[0.04]"
                       >
                         <div className="flex flex-1 items-center gap-2 overflow-hidden">
                           <span
                             aria-hidden
-                            className="flex size-[34px] shrink-0 items-center justify-center rounded-[10px] bg-white/[0.04] text-lg"
+                            className="flex size-[34px] shrink-0 items-center justify-center rounded-[10px] bg-black/[0.04] text-lg"
                           >
                             {item.category}
                           </span>
@@ -419,7 +419,7 @@ export const MonthlyBudgetBlocks = ({ yearlySpending }: Props) => {
                             onClick={() =>
                               handleOpenEditModal(month.value, item.index)
                             }
-                            className="text-primary-400 hover:bg-white/[0.05] min-h-8 min-w-8 rounded-lg p-2 transition-colors"
+                            className="text-primary-400 min-h-8 min-w-8 rounded-lg p-2 transition-colors hover:bg-black/[0.05]"
                             aria-label="編輯"
                           >
                             <EditIcon className="size-4" />
@@ -429,7 +429,7 @@ export const MonthlyBudgetBlocks = ({ yearlySpending }: Props) => {
                             onClick={() =>
                               handleDeleteItem(month.value, item.index)
                             }
-                            className="hover:bg-white/[0.05] min-h-8 min-w-8 rounded-lg p-2 transition-colors"
+                            className="min-h-8 min-w-8 rounded-lg p-2 transition-colors hover:bg-black/[0.05]"
                             style={{ color: 'var(--color-expense)' }}
                             aria-label="刪除"
                           >
@@ -448,7 +448,7 @@ export const MonthlyBudgetBlocks = ({ yearlySpending }: Props) => {
                 <button
                   type="button"
                   onClick={() => handleOpenAddModal(month.value)}
-                  className="text-primary-400 hover:text-primary-300 mt-1 cursor-pointer self-end text-sm font-semibold transition-colors"
+                  className="text-primary-500 hover:text-primary-400 mt-1 cursor-pointer self-end text-sm font-semibold transition-colors"
                 >
                   + 新增項目
                 </button>
@@ -486,7 +486,7 @@ export const MonthlyBudgetBlocks = ({ yearlySpending }: Props) => {
                   )
                 }
                 onChange={setItemCategory}
-                className="h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 transition-colors hover:border-primary-500 active:border-primary-500"
+                className="hover:border-primary-500 active:border-primary-500 h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 transition-colors"
               >
                 {ALL_CATEGORIES.map((category) => (
                   <Select.Item key={category.value} value={category.value}>
@@ -505,7 +505,7 @@ export const MonthlyBudgetBlocks = ({ yearlySpending }: Props) => {
               </legend>
               <input
                 type="text"
-                className="h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 placeholder:text-gray-500 focus:outline-none focus:border-primary-500"
+                className="focus:border-primary-500 h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 placeholder:text-gray-500 focus:outline-none"
                 value={itemDescription}
                 onChange={(e) => setItemDescription(e.target.value)}
                 placeholder={`例如：房租、午餐、薪水（預設：${selectedCategoryLabel}）`}
@@ -516,7 +516,7 @@ export const MonthlyBudgetBlocks = ({ yearlySpending }: Props) => {
               <legend className="mb-2">預算金額</legend>
               <input
                 type="number"
-                className="h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 placeholder:text-gray-500 focus:outline-none focus:border-primary-500"
+                className="focus:border-primary-500 h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 placeholder:text-gray-500 focus:outline-none"
                 value={itemAmount || ''}
                 onChange={(e) => setItemAmount(Number(e.target.value))}
                 placeholder="5000"

--- a/my-app/src/app/budget/MonthlyBudgetSection.tsx
+++ b/my-app/src/app/budget/MonthlyBudgetSection.tsx
@@ -43,11 +43,10 @@ export const MonthlyBudgetSection = ({ yearlySpending }: Props) => {
 
   return (
     <div
-      className="relative flex w-full flex-col gap-3 overflow-hidden rounded-2xl border p-5 shadow-md backdrop-blur-sm"
+      className="relative flex w-full flex-col gap-3 overflow-hidden rounded-2xl border p-5 backdrop-blur-sm"
       style={{
-        borderColor: 'rgba(6, 182, 212, 0.30)',
-        background:
-          'linear-gradient(180deg, rgba(6,182,212,0.10), rgba(6,182,212,0.02))',
+        borderColor: 'rgba(0, 102, 204, 0.30)',
+        background: 'var(--color-bg-primary)',
         textWrap: 'pretty',
       }}
     >
@@ -55,7 +54,7 @@ export const MonthlyBudgetSection = ({ yearlySpending }: Props) => {
         className="text-[11px] font-semibold uppercase"
         style={{
           letterSpacing: '0.12em',
-          color: 'var(--color-primary-400)',
+          color: 'var(--color-primary-500)',
         }}
       >
         本月預算
@@ -69,7 +68,7 @@ export const MonthlyBudgetSection = ({ yearlySpending }: Props) => {
       >
         ${normalizeNumber(monthlyBudget)}
       </p>
-      <div className="h-1 w-full overflow-hidden rounded-full bg-white/[0.06]">
+      <div className="h-1 w-full overflow-hidden rounded-full bg-black/[0.06]">
         <div
           className="h-full rounded-full transition-all duration-300"
           style={{

--- a/my-app/src/app/budget/MonthlyItemsList.tsx
+++ b/my-app/src/app/budget/MonthlyItemsList.tsx
@@ -156,7 +156,7 @@ export const MonthlyItemsList = () => {
         <button
           type="button"
           onClick={handleOpenAdd}
-          className="bg-text text-background rounded-lg px-4 py-2 text-sm font-bold transition-colors hover:bg-gray-800 active:bg-gray-800"
+          className="bg-text text-background rounded-lg px-4 py-2 text-sm font-semibold transition-all hover:opacity-85 active:scale-95"
         >
           + 新增項目
         </button>
@@ -170,7 +170,7 @@ export const MonthlyItemsList = () => {
             return (
               <div
                 key={index}
-                className="flex items-center justify-between rounded-lg border border-solid border-gray-200 p-3"
+                className="flex items-center justify-between rounded-lg border border-solid border-gray-700 p-3"
               >
                 <div className="flex-1">
                   <p className="font-medium">
@@ -231,7 +231,7 @@ export const MonthlyItemsList = () => {
                   )
                 }
                 onChange={setItemCategory}
-                className="h-10 w-full rounded-md border border-solid border-gray-300 px-3 py-1 transition-colors hover:border-gray-500 active:border-gray-500"
+                className="h-10 w-full rounded-md border border-solid border-gray-700 px-3 py-1 transition-colors hover:border-gray-500 active:border-gray-500"
               >
                 {ALL_CATEGORIES.map((category) => (
                   <Select.Item key={category.value} value={category.value}>
@@ -250,7 +250,7 @@ export const MonthlyItemsList = () => {
               </legend>
               <input
                 type="text"
-                className="h-10 w-full rounded-md border border-solid border-gray-300 px-3 py-1"
+                className="h-10 w-full rounded-md border border-solid border-gray-700 px-3 py-1"
                 value={itemDescription}
                 onChange={(e) => setItemDescription(e.target.value)}
                 placeholder={`例如：房租、午餐、薪水（預設：${selectedCategoryLabel}）`}
@@ -262,12 +262,12 @@ export const MonthlyItemsList = () => {
               <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                 {MONTHS.map((month) => (
                   <div key={month.value} className="flex flex-col">
-                    <label className="mb-1 text-sm text-gray-600">
+                    <label className="mb-1 text-sm text-gray-400">
                       {month.label}
                     </label>
                     <input
                       type="number"
-                      className="h-9 w-full rounded-md border border-solid border-gray-300 px-2 py-1 text-sm"
+                      className="h-9 w-full rounded-md border border-solid border-gray-700 px-2 py-1 text-sm"
                       value={monthlyAmounts[month.value] || ''}
                       onChange={(e) =>
                         handleMonthAmountChange(month.value, e.target.value)
@@ -284,7 +284,7 @@ export const MonthlyItemsList = () => {
                 type="button"
                 onClick={() => setModalOpen(false)}
                 disabled={saving}
-                className="rounded-lg border border-solid border-gray-300 px-4 py-2 text-gray-300"
+                className="rounded-lg border border-solid border-gray-700 px-4 py-2 text-gray-300"
               >
                 取消
               </button>
@@ -292,7 +292,7 @@ export const MonthlyItemsList = () => {
                 type="button"
                 onClick={handleSaveItem}
                 disabled={saving}
-                className="bg-text text-background flex items-center justify-center rounded-lg px-6 py-2 font-bold transition-colors hover:bg-gray-800 active:bg-gray-800 disabled:cursor-not-allowed disabled:bg-gray-400"
+                className="bg-text text-background flex items-center justify-center rounded-lg px-6 py-2 font-semibold transition-all hover:opacity-85 active:scale-95 disabled:cursor-not-allowed disabled:bg-gray-400"
               >
                 {saving ? (
                   <Loading className="size-5 animate-spin" />

--- a/my-app/src/app/budget/RecurringBudgetItems.tsx
+++ b/my-app/src/app/budget/RecurringBudgetItems.tsx
@@ -47,7 +47,12 @@ export const RecurringBudgetItems = () => {
       .map((item, index) => {
         const amount = getRecurringAmount(item);
         return amount !== null
-          ? { index, category: item.category, description: item.description, amount }
+          ? {
+              index,
+              category: item.category,
+              description: item.description,
+              amount,
+            }
           : null;
       })
       .filter((x): x is NonNullable<typeof x> => x !== null);
@@ -73,11 +78,7 @@ export const RecurringBudgetItems = () => {
   };
 
   const handleSave = useCallback(async () => {
-    if (
-      !currentGroup?.account_id ||
-      !itemCategory.trim() ||
-      itemAmount <= 0
-    ) {
+    if (!currentGroup?.account_id || !itemCategory.trim() || itemAmount <= 0) {
       alert('請填寫類別與大於 0 的金額');
       return;
     }
@@ -103,8 +104,7 @@ export const RecurringBudgetItems = () => {
         // it to recurring instead of creating a duplicate.
         const existingIdx = budget?.monthly_items?.findIndex(
           (it) =>
-            it.category === itemCategory &&
-            it.description === finalDescription,
+            it.category === itemCategory && it.description === finalDescription,
         );
         if (existingIdx !== undefined && existingIdx >= 0) {
           newItems = [...(budget?.monthly_items || [])];
@@ -176,7 +176,7 @@ export const RecurringBudgetItems = () => {
   return (
     <>
       <section
-        className="flex w-full flex-col gap-3 rounded-2xl border bg-gray-800/80 p-5 shadow-md backdrop-blur-sm md:max-w-250"
+        className="flex w-full flex-col gap-3 rounded-2xl border bg-gray-950 p-5 backdrop-blur-sm md:max-w-250"
         style={{ borderColor: 'rgba(255,255,255,0.06)' }}
       >
         <header className="flex items-center justify-between gap-3">
@@ -194,7 +194,7 @@ export const RecurringBudgetItems = () => {
           <button
             type="button"
             onClick={handleOpenAdd}
-            className="text-primary-400 hover:text-primary-300 shrink-0 cursor-pointer text-sm font-semibold transition-colors"
+            className="text-primary-500 hover:text-primary-400 shrink-0 cursor-pointer text-sm font-semibold transition-colors"
           >
             + 新增固定項目
           </button>
@@ -206,12 +206,12 @@ export const RecurringBudgetItems = () => {
               {recurringItems.map((item) => (
                 <li
                   key={`recurring-${item.index}`}
-                  className="flex items-center justify-between gap-2 rounded-xl border border-white/[0.06] bg-white/[0.02] px-3 py-2 transition-colors hover:bg-white/[0.04]"
+                  className="flex items-center justify-between gap-2 rounded-xl border border-black/[0.08] bg-black/[0.02] px-3 py-2 transition-colors hover:bg-black/[0.04]"
                 >
                   <div className="flex flex-1 items-center gap-2 overflow-hidden">
                     <span
                       aria-hidden
-                      className="flex size-[34px] shrink-0 items-center justify-center rounded-[10px] bg-white/[0.04] text-lg"
+                      className="flex size-[34px] shrink-0 items-center justify-center rounded-[10px] bg-black/[0.04] text-lg"
                     >
                       {item.category}
                     </span>
@@ -231,7 +231,7 @@ export const RecurringBudgetItems = () => {
                     <button
                       type="button"
                       onClick={() => handleOpenEdit(item.index)}
-                      className="text-primary-400 hover:bg-white/[0.05] min-h-8 min-w-8 rounded-lg p-2 transition-colors"
+                      className="text-primary-400 min-h-8 min-w-8 rounded-lg p-2 transition-colors hover:bg-black/[0.05]"
                       aria-label="編輯"
                     >
                       <EditIcon className="size-4" />
@@ -239,7 +239,7 @@ export const RecurringBudgetItems = () => {
                     <button
                       type="button"
                       onClick={() => handleDelete(item.index)}
-                      className="hover:bg-white/[0.05] min-h-8 min-w-8 rounded-lg p-2 transition-colors"
+                      className="min-h-8 min-w-8 rounded-lg p-2 transition-colors hover:bg-black/[0.05]"
                       style={{ color: 'var(--color-expense)' }}
                       aria-label="刪除"
                     >
@@ -271,7 +271,9 @@ export const RecurringBudgetItems = () => {
           defaultOpen={true}
           onClose={() => setModalOpen(false)}
           className="flex w-full flex-col self-end sm:max-w-96 sm:self-center sm:rounded-xl"
-          title={editingIndex !== null ? '編輯固定預算項目' : '新增固定預算項目'}
+          title={
+            editingIndex !== null ? '編輯固定預算項目' : '新增固定預算項目'
+          }
         >
           <div className="flex w-full flex-col gap-4">
             <fieldset>
@@ -290,7 +292,7 @@ export const RecurringBudgetItems = () => {
                   )
                 }
                 onChange={setItemCategory}
-                className="h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 transition-colors hover:border-primary-500 active:border-primary-500"
+                className="hover:border-primary-500 active:border-primary-500 h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 transition-colors"
               >
                 {ALL_CATEGORIES.map((category) => (
                   <Select.Item key={category.value} value={category.value}>
@@ -309,7 +311,7 @@ export const RecurringBudgetItems = () => {
               </legend>
               <input
                 type="text"
-                className="h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 placeholder:text-gray-500 focus:outline-none focus:border-primary-500"
+                className="focus:border-primary-500 h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 placeholder:text-gray-500 focus:outline-none"
                 value={itemDescription}
                 onChange={(e) => setItemDescription(e.target.value)}
                 placeholder={`例如：房租、薪水、Netflix（預設：${selectedCategoryLabel}）`}
@@ -320,7 +322,7 @@ export const RecurringBudgetItems = () => {
               <legend className="mb-2">每月金額（會套用到 1–12 月）</legend>
               <input
                 type="number"
-                className="h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 placeholder:text-gray-500 focus:outline-none focus:border-primary-500"
+                className="focus:border-primary-500 h-10 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-1 text-gray-100 placeholder:text-gray-500 focus:outline-none"
                 value={itemAmount || ''}
                 onChange={(e) => setItemAmount(Number(e.target.value))}
                 placeholder="例如：20000"

--- a/my-app/src/app/budget/RecurringBudgetItems.tsx
+++ b/my-app/src/app/budget/RecurringBudgetItems.tsx
@@ -177,7 +177,7 @@ export const RecurringBudgetItems = () => {
     <>
       <section
         className="flex w-full flex-col gap-3 rounded-2xl border bg-gray-950 p-5 backdrop-blur-sm md:max-w-250"
-        style={{ borderColor: 'rgba(255,255,255,0.06)' }}
+        style={{ borderColor: 'var(--color-line)' }}
       >
         <header className="flex items-center justify-between gap-3">
           <div className="flex flex-col gap-0.5">

--- a/my-app/src/app/globals.css
+++ b/my-app/src/app/globals.css
@@ -1,51 +1,39 @@
-/* Google Fonts - Poppins (Headings) + Open Sans (Body) */
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;600;700&family=Poppins:wght@400;500;600;700;800&display=swap');
-
 @import 'tailwindcss';
 
 :root {
-  /* Spacing System (8px base) */
+  /* Spacing System (8px base — DESIGN.md spacing tokens) */
   --spacing-0: 0;
-  --spacing-1: 0.25rem; /* 4px */
-  --spacing-2: 0.5rem; /* 8px */
-  --spacing-3: 0.75rem; /* 12px */
+  --spacing-1: 0.25rem; /* 4px  — {spacing.xxs} */
+  --spacing-2: 0.5rem; /* 8px  — {spacing.xs} */
+  --spacing-3: 0.75rem; /* 12px — {spacing.sm} */
   --spacing-4: 1rem; /* 16px */
   --spacing-5: 1.25rem; /* 20px */
-  --spacing-6: 1.5rem; /* 24px */
-  --spacing-8: 2rem; /* 32px */
+  --spacing-6: 1.5rem; /* 24px — {spacing.lg} */
+  --spacing-8: 2rem; /* 32px — {spacing.xl} */
   --spacing-10: 2.5rem; /* 40px */
-  --spacing-12: 3rem; /* 48px */
+  --spacing-12: 3rem; /* 48px — {spacing.xxl} */
   --spacing-16: 4rem; /* 64px */
-  --spacing-20: 5rem; /* 80px */
+  --spacing-20: 5rem; /* 80px — {spacing.section} */
 
-  /* Border Radius */
-  --radius-sm: 0.375rem; /* 6px */
-  --radius-md: 0.5rem; /* 8px */
-  --radius-lg: 0.75rem; /* 12px */
-  --radius-xl: 1rem; /* 16px */
-  --radius-2xl: 1.5rem; /* 24px */
-  --radius-full: 9999px;
+  /* Border Radius — DESIGN.md rounded scale */
+  --radius-sm: 0.3125rem; /* 5px  — {rounded.xs} */
+  --radius-md: 0.5rem; /* 8px  — {rounded.sm} */
+  --radius-lg: 0.6875rem; /* 11px — {rounded.md} */
+  --radius-xl: 1.125rem; /* 18px — {rounded.lg} */
+  --radius-2xl: 1.125rem; /* 18px — {rounded.lg} */
+  --radius-full: 9999px; /* {rounded.pill} */
 
-  /* Shadows - Dark theme optimized */
-  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
-  --shadow-md:
-    0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -2px rgba(0, 0, 0, 0.3);
-  --shadow-lg:
-    0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -4px rgba(0, 0, 0, 0.4);
-  --shadow-xl:
-    0 20px 25px -5px rgba(0, 0, 0, 0.5), 0 8px 10px -6px rgba(0, 0, 0, 0.4);
-  --shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+  /* Shadows — chrome stays flat; soft neutral elevation reserved for
+     floating layers (dropdowns / modals / sticky bars) only */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 10px 24px rgba(0, 0, 0, 0.1);
+  --shadow-xl: 0 20px 40px rgba(0, 0, 0, 0.12);
+  --shadow-2xl: 0 25px 50px -12px rgba(0, 0, 0, 0.16);
 
-  /* Glow Shadows - Unified for all primary colors */
-  --shadow-glow: 0 0 20px 0 rgba(34, 211, 238, 0.15);
-  --shadow-glow-lg: 0 0 40px 0 rgba(34, 211, 238, 0.25);
-  --shadow-glow-intense: 0 0 60px 0 rgba(34, 211, 238, 0.35);
-
-  /* Color-specific glows for consistency */
-  --shadow-primary-glow: 0 0 20px 0 rgba(6, 182, 212, 0.25);
-  --shadow-secondary-glow: 0 0 20px 0 rgba(139, 92, 246, 0.25);
-  --shadow-accent-glow: 0 0 20px 0 rgba(59, 130, 246, 0.25);
-  --shadow-income-glow: 0 0 20px 0 rgba(16, 185, 129, 0.25);
+  /* Product shadow — the single signature drop-shadow in the system,
+     reserved for imagery resting on a surface */
+  --shadow-product: rgba(0, 0, 0, 0.22) 3px 5px 30px 0;
 
   /* Transitions */
   --duration-fast: 150ms;
@@ -59,160 +47,158 @@
   --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
   --ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 
-  /* Typography */
-  --font-heading: 'Poppins', -apple-system, BlinkMacSystemFont, sans-serif;
-  --font-body: 'Open Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  /* Typography — SF Pro with system fallbacks (DESIGN.md font stack) */
+  --font-heading:
+    'SF Pro Display', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-body:
+    'SF Pro Text', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   --font-mono: 'SF Mono', 'Consolas', 'Monaco', monospace;
 
-  /* Font Weights */
+  /* Font Weights — ladder is 300 / 400 / 600 / 700; 500 deliberately absent */
   --font-light: 300;
   --font-normal: 400;
-  --font-medium: 500;
+  --font-medium: 600;
   --font-semibold: 600;
   --font-bold: 700;
-  --font-extrabold: 800;
+  --font-extrabold: 700;
 
   /* Line Heights */
-  --leading-tight: 1.25;
-  --leading-normal: 1.5;
+  --leading-tight: 1.1;
+  --leading-normal: 1.47;
   --leading-relaxed: 1.75;
-  --leading-loose: 2;
+  --leading-loose: 2.41;
 
-  /* Semantic Colors */
-  --color-success: #34d399;
-  --color-warning: #fbbf24;
-  --color-error: #f87171;
-  --color-info: #60a5fa;
+  /* Semantic Colors (light surfaces) */
+  --color-success: #248a3d;
+  --color-warning: #b25000;
+  --color-error: #e30000;
+  --color-info: #0066cc;
 
   /* Money Semantics — 紅 = 支出 / 綠 = 收入 / 鮮紅 = 超支 / 琥珀 = 80–99% */
-  --color-income: #34d399;
-  --color-income-bg: rgba(52, 211, 153, 0.1);
-  --color-expense: #f87171;
-  --color-expense-bg: rgba(248, 113, 113, 0.1);
-  --color-over-budget: #fb7185;
-  --color-over-budget-bg: rgba(251, 113, 133, 0.1);
+  --color-income: #248a3d;
+  --color-income-bg: rgba(36, 138, 61, 0.08);
+  --color-expense: #e30000;
+  --color-expense-bg: rgba(227, 0, 0, 0.06);
+  --color-over-budget: #e30000;
+  --color-over-budget-bg: rgba(227, 0, 0, 0.08);
 
-  /* Hairline borders — 全站統一 */
-  --color-line: rgba(255, 255, 255, 0.06);
-  --color-line-soft: rgba(255, 255, 255, 0.04);
+  /* Hairline borders — 全站統一（DESIGN.md hairline / divider-soft） */
+  --color-line: rgba(0, 0, 0, 0.08);
+  --color-line-soft: rgba(0, 0, 0, 0.04);
 
-  /* Unified card shadow — 取代多重陰影 */
-  --shadow-card:
-    inset 0 1px 0 rgba(255, 255, 255, 0.04),
-    0 8px 20px rgba(0, 0, 0, 0.25);
+  /* Cards are flat — elevation comes from surface change + hairline,
+     never from shadows on chrome */
+  --shadow-card: none;
 
-  /* Radii — 統一 */
-  --radius-card: 16px;
-  --radius-tile: 12px;
-  --radius-button: 10px;
-  --radius-pill: 9999px;
+  /* Radii — 統一（DESIGN.md rounded scale） */
+  --radius-card: 18px; /* {rounded.lg} — utility cards */
+  --radius-tile: 11px; /* {rounded.md} — pearl capsules */
+  --radius-button: 8px; /* {rounded.sm} — compact utility buttons */
+  --radius-pill: 9999px; /* {rounded.pill} — primary CTA grammar */
 
-  /* Background Colors - Dark theme */
-  --color-bg-primary: #0a0e1a; /* 深邃夜空 */
-  --color-bg-secondary: #111827; /* 稍亮的深色 */
-  --color-bg-elevated: #1e293b; /* 卡片背景 */
+  /* Background Colors — light canvas system */
+  --color-bg-primary: #ffffff; /* {colors.canvas} */
+  --color-bg-secondary: #f5f5f7; /* {colors.canvas-parchment} */
+  --color-bg-elevated: #fafafc; /* {colors.surface-pearl} */
 
-  /* Text Colors - Dark theme (WCAG AA compliant) */
-  --color-text-primary: #f1f5f9; /* 主要文字 - 16.5:1 on bg-primary */
-  --color-text-secondary: #cbd5e1; /* 次要文字 - 10.5:1 on bg-primary, 5.5:1 on bg-elevated */
-  --color-text-tertiary: #94a3b8; /* 提示文字 - 7.2:1 on bg-primary, 4.5:1 on bg-elevated */
-  --color-text-inverse: #0f172a; /* 反色文字 */
+  /* Text Colors — near-black ink, never pure black */
+  --color-text-primary: #1d1d1f; /* {colors.ink} */
+  --color-text-secondary: #333333; /* {colors.ink-muted-80} */
+  --color-text-tertiary: #7a7a7a; /* {colors.ink-muted-48} */
+  --color-text-inverse: #ffffff; /* {colors.on-dark} */
 
-  /* Border Colors - Dark theme */
-  --color-border-light: #1e293b;
-  --color-border-default: #334155;
-  --color-border-strong: #475569;
+  /* Border Colors */
+  --color-border-light: #f0f0f0; /* {colors.divider-soft} */
+  --color-border-default: #e0e0e0; /* {colors.hairline} */
+  --color-border-strong: #d2d2d7; /* {colors.surface-chip-translucent} */
 }
 
 @theme {
-  /* Background and Text - Solo Leveling Dark Theme */
-  --color-background: #0a0e1a;
-  --color-text: #f1f5f9;
+  /* Background and Text — Apple-style light canvas */
+  --color-background: #ffffff;
+  --color-text: #1d1d1f;
 
-  /* Primary - Cyan/Teal (主色系 - 青藍色，類似獨自升級的發光效果) */
-  --color-primary-50: #ecfeff;
-  --color-primary-100: #cffafe;
-  --color-primary-200: #a5f3fc;
-  --color-primary-300: #67e8f9;
-  --color-primary-400: #22d3ee;
-  --color-primary-500: #06b6d4; /* Main Cyan */
-  --color-primary-600: #0891b2;
-  --color-primary-700: #0e7490;
-  --color-primary-800: #155e75;
-  --color-primary-900: #164e63;
-  --color-primary-950: #083344;
+  /* Primary — Action Blue (單一互動色，所有 "click me" 訊號) */
+  --color-primary-50: #f2f7fc;
+  --color-primary-100: #d9e8f7;
+  --color-primary-200: #b3d1ef;
+  --color-primary-300: #6ba6e0;
+  --color-primary-400: #0071e3; /* {colors.primary-focus} */
+  --color-primary-500: #0066cc; /* {colors.primary} — Action Blue */
+  --color-primary-600: #0055ab;
+  --color-primary-700: #00468c;
+  --color-primary-800: #00386f;
+  --color-primary-900: #002b55;
+  --color-primary-950: #001f3d;
 
-  /* Secondary - Violet (副色系 - 電光紫，更冷調，更協調) */
-  --color-secondary-50: #f5f3ff;
-  --color-secondary-100: #ede9fe;
-  --color-secondary-200: #ddd6fe;
-  --color-secondary-300: #c4b5fd;
-  --color-secondary-400: #a78bfa;
-  --color-secondary-500: #8b5cf6; /* Main Violet (統一冷色調) */
-  --color-secondary-600: #7c3aed;
-  --color-secondary-700: #6d28d9;
-  --color-secondary-800: #5b21b6;
-  --color-secondary-900: #4c1d95;
-  --color-secondary-950: #2e1065;
+  /* Secondary — 無第二品牌色：全部對齊 Action Blue（單一強調色原則） */
+  --color-secondary-50: var(--color-primary-50);
+  --color-secondary-100: var(--color-primary-100);
+  --color-secondary-200: var(--color-primary-200);
+  --color-secondary-300: var(--color-primary-300);
+  --color-secondary-400: var(--color-primary-400);
+  --color-secondary-500: var(--color-primary-500);
+  --color-secondary-600: var(--color-primary-600);
+  --color-secondary-700: var(--color-primary-700);
+  --color-secondary-800: var(--color-primary-800);
+  --color-secondary-900: var(--color-primary-900);
+  --color-secondary-950: var(--color-primary-950);
 
-  /* Accent - Electric Blue (輔助色系 - 電光藍) */
-  --color-accent-50: #eff6ff;
-  --color-accent-100: #dbeafe;
-  --color-accent-200: #bfdbfe;
-  --color-accent-300: #93c5fd;
-  --color-accent-400: #60a5fa;
-  --color-accent-500: #3b82f6; /* Main Blue */
-  --color-accent-600: #2563eb;
-  --color-accent-700: #1d4ed8;
-  --color-accent-800: #1e40af;
-  --color-accent-900: #1e3a8a;
+  /* Accent — 同上，對齊 Action Blue */
+  --color-accent-50: var(--color-primary-50);
+  --color-accent-100: var(--color-primary-100);
+  --color-accent-200: var(--color-primary-200);
+  --color-accent-300: var(--color-primary-300);
+  --color-accent-400: var(--color-primary-400);
+  --color-accent-500: var(--color-primary-500);
+  --color-accent-600: var(--color-primary-600);
+  --color-accent-700: var(--color-primary-700);
+  --color-accent-800: var(--color-primary-800);
+  --color-accent-900: var(--color-primary-900);
 
-  /* Income - Emerald Green (收入 - 翡翠綠) */
-  --color-income-50: #ecfdf5;
-  --color-income-100: #d1fae5;
-  --color-income-200: #a7f3d0;
-  --color-income-300: #6ee7b7;
-  --color-income-400: #34d399;
-  --color-income-500: #10b981; /* Main Emerald */
-  --color-income-600: #059669;
-  --color-income-700: #047857;
-  --color-income-800: #065f46;
-  --color-income-900: #064e3b;
+  /* Income — Green（功能性財務語意色，非裝飾） */
+  --color-income-50: #f0faf3;
+  --color-income-100: #d8f3e0;
+  --color-income-200: #b0e7c3;
+  --color-income-300: #7dd89e;
+  --color-income-400: #2da44e;
+  --color-income-500: #248a3d; /* Main Green — 在白底可讀 */
+  --color-income-600: #1a7f37;
+  --color-income-700: #156a2e;
+  --color-income-800: #105524;
+  --color-income-900: #0b401b;
 
-  /* Slate Grays - Cool toned for dark theme (WCAG optimized) */
-  --color-gray-50: #f8fafc;
-  --color-gray-100: #f1f5f9;
-  --color-gray-200: #e2e8f0;
-  --color-gray-300: #cbd5e1; /* Use for secondary text */
-  --color-gray-400: #94a3b8; /* Use for tertiary/muted text */
-  --color-gray-500: #64748b; /* Use sparingly - low contrast on dark */
-  --color-gray-600: #475569;
-  --color-gray-700: #334155;
-  --color-gray-800: #1e293b; /* Card/elevated background */
-  --color-gray-900: #0f172a;
-  --color-gray-950: #020617;
+  /* Grays — 語意反轉對應：深色主題的「亮字 / 暗面」自動轉為
+     淺色主題的「墨字 / 淺面」。沿用既有 class 不需逐一改寫。 */
+  --color-gray-50: #1d1d1f; /* 最強調文字 → ink */
+  --color-gray-100: #1d1d1f; /* 主要文字 → ink */
+  --color-gray-200: #333333; /* 次要文字 → ink-muted-80 */
+  --color-gray-300: #494949; /* 次要文字（柔和） */
+  --color-gray-400: #7a7a7a; /* 提示文字 → ink-muted-48 */
+  --color-gray-500: #86868b; /* 弱化文字 */
+  --color-gray-600: #d2d2d7; /* 較強邊框 → chip translucent */
+  --color-gray-700: #e0e0e0; /* 預設邊框 → hairline */
+  --color-gray-800: #f5f5f7; /* 卡片/表面 → parchment */
+  --color-gray-900: #fafafc; /* 更淺表面 → pearl */
+  --color-gray-950: #ffffff; /* 純白 canvas */
 
   /* Legacy accent colors for compatibility */
-  --color-accent-lavender-100: var(--color-secondary-100);
-  --color-accent-lavender-500: var(--color-secondary-500);
-  --color-accent-orchid-100: var(--color-secondary-200);
-  --color-accent-orchid-500: var(--color-secondary-600);
+  --color-accent-lavender-100: var(--color-primary-100);
+  --color-accent-lavender-500: var(--color-primary-500);
+  --color-accent-orchid-100: var(--color-primary-200);
+  --color-accent-orchid-500: var(--color-primary-600);
   --color-accent-mint-100: var(--color-income-100);
   --color-accent-mint-500: var(--color-income-500);
   --color-accent-peach-100: var(--color-primary-100);
   --color-accent-peach-500: var(--color-primary-500);
 
-  /* Scrollbar - Dark theme */
-  --color-scrollbar-thumb: #475569;
-  --color-scrollbar-thumb-hover: #64748b;
+  /* Scrollbar — light theme */
+  --color-scrollbar-thumb: #d2d2d7;
+  --color-scrollbar-thumb-hover: #a1a1a6;
 
-  /* Special Shadows - Glow effects */
-  --shadow-primary:
-    0px 0px 0px 1px var(--color-primary-500),
-    0px 0px 20px -4px var(--color-primary-500);
-  --shadow-primary-hover:
-    0px 0px 0px 1px var(--color-primary-400),
-    0px 0px 30px -4px var(--color-primary-400);
+  /* Focus ring shadows（取代舊 glow） */
+  --shadow-primary: 0 0 0 2px var(--color-primary-400);
+  --shadow-primary-hover: 0 0 0 2px var(--color-primary-500);
 }
 
 body {
@@ -225,8 +211,10 @@ body {
   flex-direction: column;
   overflow-y: scroll;
   padding-bottom: 5rem;
-  font-size: 1rem;
+  /* Body copy at 17px / 1.47 / -0.374px — the brand reading pace */
+  font-size: 1.0625rem;
   line-height: var(--leading-normal);
+  letter-spacing: -0.022em;
   text-wrap: pretty;
 }
 
@@ -248,7 +236,6 @@ body {
 @media (min-width: 768px) {
   body {
     padding-bottom: 0;
-    font-size: 1.0625rem;
   }
 }
 
@@ -259,27 +246,28 @@ h4,
 h5,
 h6 {
   font-family: var(--font-heading);
+  /* Headlines sit at weight 600, never 700 */
   font-weight: var(--font-semibold);
   line-height: var(--leading-tight);
+  /* Negative tracking at display sizes — the signature tight cadence */
+  letter-spacing: -0.015em;
 }
 
 /* Headings responsive sizes */
 h1 {
-  font-size: 2.25rem;
-  font-weight: var(--font-bold);
+  font-size: 2.125rem; /* 34px — {typography.display-md} */
 }
 h2 {
-  font-size: 1.875rem;
-  font-weight: var(--font-semibold);
+  font-size: 1.75rem; /* 28px */
 }
 h3 {
-  font-size: 1.5rem;
+  font-size: 1.3125rem; /* 21px — {typography.tagline} */
 }
 h4 {
-  font-size: 1.25rem;
+  font-size: 1.1875rem; /* 19px */
 }
 h5 {
-  font-size: 1.125rem;
+  font-size: 1.0625rem; /* 17px — {typography.body-strong} */
 }
 h6 {
   font-size: 1rem;
@@ -287,62 +275,25 @@ h6 {
 
 @media (min-width: 768px) {
   h1 {
-    font-size: 2.5rem;
+    font-size: 2.5rem; /* 40px — {typography.display-lg} */
   }
   h2 {
     font-size: 2rem;
   }
 }
 
+/* Flat parchment surface — 色彩變化本身就是分隔，無漸層 */
 .bg-radial {
-  background-image:
-    radial-gradient(
-      circle at 0% 0%,
-      rgba(6, 182, 212, 0.15) 0%,
-      transparent 50%
-    ),
-    radial-gradient(
-      circle at 100% 100%,
-      rgba(168, 85, 247, 0.12) 0%,
-      transparent 50%
-    );
+  background-color: var(--color-bg-secondary);
 }
 
 .bg-grid {
-  background-image:
-    linear-gradient(to right, rgba(71, 85, 105, 0.3) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(71, 85, 105, 0.3) 1px, transparent 1px);
-  background-size: 24px 24px;
+  background-color: var(--color-bg-secondary);
 }
 
-/* Solo Leveling inspired dark background with glowing gradients */
+/* Page canvas — parchment（{colors.canvas-parchment}），純色、無光暈 */
 .bg-soft {
-  background-color: var(--color-bg-primary);
-  background-image:
-    /* Cyan glow top-left */
-    radial-gradient(
-      ellipse at 0% 0%,
-      rgba(6, 182, 212, 0.15) 0%,
-      transparent 50%
-    ),
-    /* Purple glow bottom-right */
-    radial-gradient(
-        ellipse at 100% 100%,
-        rgba(168, 85, 247, 0.12) 0%,
-        transparent 50%
-      ),
-    /* Blue accent top-right */
-    radial-gradient(
-        ellipse at 100% 0%,
-        rgba(59, 130, 246, 0.08) 0%,
-        transparent 40%
-      ),
-    /* Subtle cyan bottom-left */
-    radial-gradient(
-        ellipse at 0% 100%,
-        rgba(34, 211, 238, 0.06) 0%,
-        transparent 40%
-      );
+  background-color: var(--color-bg-secondary);
   position: relative;
   overflow: hidden;
 }
@@ -371,14 +322,7 @@ h6 {
   margin-bottom: 1rem;
   height: 1px;
   width: 100%;
-  background-image: linear-gradient(
-    to right,
-    transparent,
-    var(--color-primary-500),
-    var(--color-secondary-500),
-    transparent
-  );
-  opacity: 0.5;
+  background-color: var(--color-border-default);
 }
 
 button {
@@ -417,11 +361,11 @@ input[type='number'] {
 
 .scrollbar::-webkit-scrollbar-thumb {
   border-radius: 6px;
-  background-color: gray;
+  background-color: var(--color-scrollbar-thumb);
 }
 
 .scrollbar::-webkit-scrollbar-thumb:hover {
-  background-color: dimgray;
+  background-color: var(--color-scrollbar-thumb-hover);
 }
 
 .scrollbar {
@@ -433,78 +377,41 @@ input[type='number'] {
   scrollbar-color: var(--color-scrollbar-thumb-hover) var(--color-background);
 }
 
-/* Solo Leveling style gradient text */
+/* 標題強調 — 純色 ink，無漸層文字 */
 .gradient-text {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-400),
-    var(--color-secondary-500),
-    var(--color-accent-400)
-  );
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
+  color: var(--color-text-primary);
 }
 
-/* Glow gradient backgrounds - Solo Leveling style */
+/* 純色 Action Blue 表面（沿用既有 class 名稱，移除漸層） */
 .gradient-glow {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-600) 0%,
-    var(--color-secondary-600) 100%
-  );
+  background: var(--color-primary-500);
 }
 
 .gradient-glow-soft {
-  background: linear-gradient(
-    135deg,
-    rgba(6, 182, 212, 0.1) 0%,
-    rgba(168, 85, 247, 0.1) 100%
-  );
+  background: var(--color-primary-50);
 }
 
-/* Intense glow for CTAs */
 .gradient-intense {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-500) 0%,
-    var(--color-accent-500) 50%,
-    var(--color-secondary-500) 100%
-  );
+  background: var(--color-primary-500);
 }
 
-/* Header quick-add CTA — desktop sticky header */
+/* Header quick-add CTA — desktop sticky header（pill、純色、scale 微互動） */
 .btn-add-header {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-500) 0%,
-    var(--color-primary-600) 100%
-  );
-  box-shadow:
-    0 0 0 1px rgba(6, 182, 212, 0.25),
-    0 4px 14px rgba(6, 182, 212, 0.28);
-  transition:
-    box-shadow var(--duration-normal) var(--ease-out),
-    transform var(--duration-fast) var(--ease-out);
+  background: var(--color-primary-500);
+  border-radius: var(--radius-pill);
+  transition: transform var(--duration-fast) var(--ease-out);
 }
 .btn-add-header:hover {
-  box-shadow:
-    0 0 0 1px rgba(6, 182, 212, 0.45),
-    0 6px 22px rgba(6, 182, 212, 0.48);
-  transform: translateY(-1px);
+  background: var(--color-primary-400);
 }
 .btn-add-header:active {
-  box-shadow:
-    0 0 0 1px rgba(6, 182, 212, 0.25),
-    0 2px 8px rgba(6, 182, 212, 0.3);
-  transform: translateY(0) scale(0.95);
+  transform: scale(0.95);
   transition-duration: 80ms;
 }
 
-/* Accessibility improvements */
+/* Accessibility improvements — focus ring in Focus Blue */
 *:focus-visible {
-  outline: 3px solid var(--color-primary-400);
+  outline: 2px solid var(--color-primary-400);
   outline-offset: 2px;
   border-radius: var(--radius-md);
 }
@@ -524,10 +431,10 @@ input[type='number'] {
 /* Animations */
 @keyframes highlight-pulse {
   0% {
-    background-color: rgba(6, 182, 212, 0.3);
+    background-color: rgba(0, 102, 204, 0.18);
   }
   50% {
-    background-color: rgba(6, 182, 212, 0.1);
+    background-color: rgba(0, 102, 204, 0.08);
   }
   100% {
     background-color: transparent;
@@ -635,12 +542,7 @@ input[type='number'] {
 }
 
 .skeleton {
-  background: linear-gradient(
-    90deg,
-    var(--color-gray-800) 25%,
-    var(--color-gray-700) 50%,
-    var(--color-gray-800) 75%
-  );
+  background: linear-gradient(90deg, #f5f5f7 25%, #e8e8ed 50%, #f5f5f7 75%);
   background-size: 200% 100%;
   animation: shimmer 1.5s ease-in-out infinite;
 }
@@ -649,142 +551,140 @@ input[type='number'] {
   transition-timing-function: cubic-bezier(0.34, 1.26, 0.64, 1);
 }
 
-/* Button Styles - Solo Leveling Dark Theme */
+/* Button Styles — pill grammar, single Action Blue, scale(0.95) press */
 .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  border-radius: 0.5rem;
-  font-weight: 600;
-  transition: all 0.2s;
+  border-radius: var(--radius-pill);
+  font-weight: 400;
+  transition:
+    background-color 0.2s,
+    transform 0.15s var(--ease-out);
   cursor: pointer;
   min-height: 44px;
   min-width: 44px;
-  padding: 0.625rem 1.25rem;
+  padding: 0.6875rem 1.375rem; /* 11px 22px — {component.button-primary} */
 }
 
+/* {component.button-primary} — 純色 Action Blue 膠囊 */
 .btn-primary {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-500),
-    var(--color-accent-500)
-  );
-  color: white;
-  padding: 0.5rem 1rem;
-  border-radius: 0.75rem;
-  font-weight: 600;
-  box-shadow: var(--shadow-glow);
-  transition: all 0.25s;
-  border: 1px solid rgba(6, 182, 212, 0.3);
+  background: var(--color-primary-500);
+  color: #ffffff;
+  padding: 0.6875rem 1.375rem;
+  border-radius: var(--radius-pill);
+  font-weight: 400;
+  transition:
+    background-color 0.2s,
+    transform 0.15s var(--ease-out);
+  border: 1px solid transparent;
 }
 
 .btn-primary:hover {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-400),
-    var(--color-accent-400)
-  );
-  box-shadow: var(--shadow-glow-lg);
-  border-color: rgba(6, 182, 212, 0.5);
+  background: var(--color-primary-400);
 }
 
 .btn-primary:active {
+  transform: scale(0.95);
 }
 
+/* {component.button-secondary-pill} — ghost pill */
 .btn-secondary {
-  background: var(--color-gray-800);
-  color: var(--color-primary-400);
-  border: 1px solid var(--color-gray-700);
-  padding: 0.5rem 1rem;
-  border-radius: 0.75rem;
-  font-weight: 600;
-  transition: all 0.2s;
+  background: transparent;
+  color: var(--color-primary-500);
+  border: 1px solid var(--color-primary-500);
+  padding: 0.6875rem 1.375rem;
+  border-radius: var(--radius-pill);
+  font-weight: 400;
+  transition:
+    background-color 0.2s,
+    transform 0.15s var(--ease-out);
 }
 
 .btn-secondary:hover {
-  background: var(--color-gray-700);
-  border-color: var(--color-primary-600);
-  box-shadow: var(--shadow-glow);
+  background: var(--color-primary-50);
 }
 
+.btn-secondary:active {
+  transform: scale(0.95);
+}
+
+/* {component.text-link} — inline action */
 .btn-ghost {
   background: transparent;
-  color: var(--color-primary-400);
+  color: var(--color-primary-500);
   padding: 0.5rem 1rem;
-  border-radius: 0.75rem;
-  font-weight: 600;
-  transition: all 0.2s;
+  border-radius: var(--radius-pill);
+  font-weight: 400;
+  transition:
+    background-color 0.2s,
+    transform 0.15s var(--ease-out);
   border: 1px solid transparent;
 }
 
 .btn-ghost:hover {
-  background: rgba(6, 182, 212, 0.1);
-  border-color: rgba(6, 182, 212, 0.3);
+  background: var(--color-primary-50);
+}
+
+.btn-ghost:active {
+  transform: scale(0.95);
 }
 
 .submit-button {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-500),
-    var(--color-accent-500)
-  );
-  color: white;
-  padding: 0.5rem 1rem;
-  border-radius: 0.75rem;
-  font-weight: 600;
-  box-shadow: var(--shadow-glow);
-  transition: all 0.25s;
-  border: 1px solid rgba(6, 182, 212, 0.3);
+  background: var(--color-primary-500);
+  color: #ffffff;
+  padding: 0.6875rem 1.375rem;
+  border-radius: var(--radius-pill);
+  font-weight: 400;
+  transition:
+    background-color 0.2s,
+    transform 0.15s var(--ease-out);
+  border: 1px solid transparent;
 }
 
 .submit-button:hover {
-  background: linear-gradient(
-    135deg,
-    var(--color-primary-400),
-    var(--color-accent-400)
-  );
-  box-shadow: var(--shadow-glow-lg);
-  border-color: rgba(6, 182, 212, 0.5);
+  background: var(--color-primary-400);
 }
 
-/* Card Styles - Solo Leveling Dark Theme (Refined) */
+.submit-button:active {
+  transform: scale(0.95);
+}
+
+/* Card Styles — {component.store-utility-card}：白底 + hairline，無陰影 */
 .card {
-  background: rgba(30, 41, 59, 0.8); /* gray-800/80 */
+  background: var(--color-bg-primary);
   border-radius: var(--radius-card);
-  padding: 1.25rem;
-  transition: background-color 0.2s, border-color 0.2s;
-  box-shadow: var(--shadow-card);
-  border: 1px solid var(--color-line);
+  padding: 1.5rem; /* {spacing.lg} 24px */
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+  border: 1px solid var(--color-border-default);
 }
 
 .card:hover {
-  background: rgba(30, 41, 59, 0.9);
-  border-color: rgba(255, 255, 255, 0.1);
+  border-color: var(--color-border-strong);
 }
 
 .card-gradient {
-  background: linear-gradient(
-    135deg,
-    rgba(6, 182, 212, 0.1) 0%,
-    rgba(168, 85, 247, 0.1) 100%
-  );
-  border: 1px solid rgba(6, 182, 212, 0.2);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-default);
 }
 
 .card-interactive {
-  background: rgba(30, 41, 59, 0.8);
+  background: var(--color-bg-primary);
   border-radius: var(--radius-card);
-  padding: 1.25rem;
-  transition: background-color 0.2s, border-color 0.2s;
-  box-shadow: var(--shadow-card);
-  border: 1px solid var(--color-line);
+  padding: 1.5rem;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s;
+  border: 1px solid var(--color-border-default);
   cursor: pointer;
 }
 
 .card-interactive:hover {
-  border-color: rgba(6, 182, 212, 0.3);
-  background: rgba(30, 41, 59, 0.95);
+  border-color: var(--color-border-strong);
+  background: var(--color-bg-elevated);
 }
 
 .animate-modal {

--- a/my-app/src/app/group/Dashboard.tsx
+++ b/my-app/src/app/group/Dashboard.tsx
@@ -253,10 +253,8 @@ const GroupCard = ({
 
   return (
     <div
-      className={`card relative grid w-full max-w-87.5 grid-cols-12 gap-4 transition-all duration-200 hover:shadow-[0_0_20px_rgba(6,182,212,0.2)] ${
-        isCurrent
-          ? 'ring-primary-400 shadow-[0_0_20px_rgba(6,182,212,0.25)] ring-2'
-          : ''
+      className={`card relative grid w-full max-w-87.5 grid-cols-12 gap-4 transition-all duration-200 ${
+        isCurrent ? 'ring-primary-400 ring-2' : ''
       }`}
     >
       <div
@@ -271,14 +269,14 @@ const GroupCard = ({
             {group.name}
           </h3>
           {isCurrent ? (
-            <span className="bg-primary-500/20 text-primary-300 ring-primary-500/40 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ring-1 ring-inset">
+            <span className="bg-primary-50 text-primary-500 ring-primary-500/40 shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ring-1 ring-inset">
               使用中
             </span>
           ) : (
             <button
               type="button"
               onClick={onSelect}
-              className="text-primary-400 hover:text-primary-300 shrink-0 text-[10px] font-semibold underline transition-colors"
+              className="text-primary-500 hover:text-primary-400 shrink-0 text-[10px] font-semibold underline transition-colors"
             >
               切換為當前帳本
             </button>
@@ -296,7 +294,7 @@ const GroupCard = ({
               <button
                 type="button"
                 onClick={() => setMembersModalOpen(true)}
-                className="text-primary-400 hover:text-primary-300 text-xs font-semibold underline transition-colors"
+                className="text-primary-500 hover:text-primary-400 text-xs font-semibold underline transition-colors"
               >
                 查看詳情
               </button>
@@ -406,7 +404,7 @@ const GroupCard = ({
           <div className="flex w-full flex-col gap-4">
             <input
               type="text"
-              className="w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-2 text-gray-100 placeholder:text-gray-500 focus:outline-none focus:border-primary-500"
+              className="focus:border-primary-500 w-full rounded-md border border-solid border-gray-600 bg-gray-900/40 px-3 py-2 text-gray-100 placeholder:text-gray-500 focus:outline-none"
               value={newGroupName}
               onChange={(e) => setNewGroupName(e.target.value)}
               placeholder="群組名稱"
@@ -450,7 +448,7 @@ const GroupCard = ({
                 return (
                   <div
                     key={member.user_id}
-                    className="hover:border-primary-500/50 flex items-center justify-between rounded-xl border border-solid border-gray-600 p-3 transition-all hover:bg-gray-700/50 hover:shadow-[0_0_10px_rgba(6,182,212,0.15)]"
+                    className="hover:border-primary-500/50 flex items-center justify-between rounded-xl border border-solid border-gray-700 p-3 transition-all hover:bg-gray-900"
                   >
                     <div className="flex-1">
                       <p className="font-semibold text-gray-100">
@@ -476,7 +474,7 @@ const GroupCard = ({
                             member.name || member.email || '未知用戶',
                           )
                         }
-                        className="text-secondary-400 hover:bg-secondary-500/20 active:bg-secondary-500/30 min-h-8 min-w-8 rounded-lg p-2 transition-all"
+                        className="text-primary-500 hover:bg-primary-50 active:bg-primary-100 min-h-8 min-w-8 rounded-lg p-2 transition-all"
                       >
                         <DeleteIcon className="size-4" />
                       </button>

--- a/my-app/src/app/group/invite/[id]/InviteConfirm.tsx
+++ b/my-app/src/app/group/invite/[id]/InviteConfirm.tsx
@@ -130,12 +130,12 @@ export const InviteConfirm = () => {
     return (
       <div className="card border-primary-300 flex w-80 flex-col border-2 text-center">
         <h2
-          className="mb-4 text-lg font-bold text-gray-800"
+          className="mb-4 text-lg font-bold text-gray-100"
           style={{ fontFamily: 'var(--font-heading)' }}
         >
           需要登入
         </h2>
-        <p className="mb-2 text-gray-600">
+        <p className="mb-2 text-gray-400">
           您收到了加入帳本
           <strong className="text-primary-600 mx-1">{invitedGroup.name}</strong>
           的邀請
@@ -152,7 +152,7 @@ export const InviteConfirm = () => {
           <button
             type="button"
             onClick={() => router.push('/')}
-            className="hover:text-primary-600 text-sm font-medium text-gray-600 transition-colors"
+            className="hover:text-primary-600 text-sm font-medium text-gray-400 transition-colors"
           >
             返回首頁
           </button>
@@ -164,7 +164,7 @@ export const InviteConfirm = () => {
   return (
     <div className="card flex w-80 flex-col pt-5 pb-4">
       <h1
-        className="mb-6 w-full px-5 text-start text-lg text-gray-800 sm:text-xl"
+        className="mb-6 w-full px-5 text-start text-lg text-gray-100 sm:text-xl"
         style={{ fontFamily: 'var(--font-heading)' }}
       >
         是否加入
@@ -174,13 +174,13 @@ export const InviteConfirm = () => {
         帳本？
       </h1>
       <div className="px-5 pb-4">
-        <p className="mb-2 text-sm font-semibold text-gray-600">帳本資訊：</p>
+        <p className="mb-2 text-sm font-semibold text-gray-400">帳本資訊：</p>
         <div className="bg-primary-50 border-primary-100 rounded-xl border p-3 text-sm">
-          <p className="text-gray-700">
+          <p className="text-gray-200">
             <span className="font-semibold">擁有者：</span>
             {invitedGroup.owner_name || invitedGroup.owner_email || '未知'}
           </p>
-          <p className="mt-1 text-gray-700">
+          <p className="mt-1 text-gray-200">
             <span className="font-semibold">成員數量：</span>
             {invitedGroup.member_count || 0} 人
           </p>
@@ -190,7 +190,7 @@ export const InviteConfirm = () => {
           （檢視者）角色
         </p>
       </div>
-      <div className="flex items-center justify-between gap-4 border-t border-solid border-gray-200 px-4 pt-4">
+      <div className="flex items-center justify-between gap-4 border-t border-solid border-gray-700 px-4 pt-4">
         <button
           type="button"
           onClick={() => router.push('/group')}
@@ -202,7 +202,7 @@ export const InviteConfirm = () => {
           type="button"
           onClick={handleJoinGroup}
           disabled={loading}
-          className="from-income-500 to-income-600 min-h-11 rounded-xl bg-linear-to-r px-6 font-semibold text-white shadow-sm transition-all hover:shadow-[0_0_20px_rgba(16,185,129,0.4)] active:shadow-[0_0_10px_rgba(16,185,129,0.3)] disabled:cursor-not-allowed disabled:opacity-50"
+          className="bg-income-500 hover:bg-income-400 min-h-11 rounded-full px-6 text-white transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {loading ? '加入中...' : '加入'}
         </button>

--- a/my-app/src/app/layout.tsx
+++ b/my-app/src/app/layout.tsx
@@ -32,16 +32,6 @@ export default function RootLayout({
     <html lang="zh-Hant-TW">
       <head>
         <title></title>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Segoe+UI:wght@400;700&display=swap"
-          rel="stylesheet"
-        />
       </head>
       <body>
         <SessionProvider>

--- a/my-app/src/app/login/page.tsx
+++ b/my-app/src/app/login/page.tsx
@@ -21,9 +21,11 @@ export default async function Home() {
 
   return (
     <div className="flex w-full flex-1 items-center justify-center bg-radial p-4">
-      <div className="flex w-full max-w-130 flex-col items-center justify-start gap-6 rounded-2xl bg-gray-800/80 border border-gray-700 p-6 shadow-lg backdrop-blur-sm">
-        <h1 className="text-2xl leading-18 font-black gradient-text">Login</h1>
-        <p className="text-gray-400 text-center">
+      <div className="flex w-full max-w-130 flex-col items-center justify-start gap-6 rounded-2xl border border-gray-700 bg-gray-950 p-6 backdrop-blur-sm">
+        <h1 className="gradient-text text-2xl leading-18 font-semibold">
+          Login
+        </h1>
+        <p className="text-center text-gray-400">
           很抱歉，該系統暫時無法透過 Email 方式註冊並登入，請先用 Google 帳號或
           Line 帳號直接登入使用，感謝您的配合。
         </p>
@@ -59,7 +61,7 @@ const SocialButton = (props: SocialButtonProps) => {
   return (
     <button
       onClick={onClick}
-      className={`flex items-center justify-center gap-3 rounded-lg border border-solid border-gray-700 bg-gray-800/60 px-6 py-3 text-gray-200 transition-all hover:border-primary-500 hover:bg-primary-900/20 hover:shadow-[0_0_15px_rgba(6,182,212,0.15)] ${className}`}
+      className={`hover:border-primary-500 hover:bg-primary-50 flex items-center justify-center gap-3 rounded-full border border-solid border-gray-700 bg-gray-950 px-6 py-3 text-gray-200 transition-all active:scale-[0.98] ${className}`}
       {...legacy}
     >
       <span className="aspect-square">{icon}</span>

--- a/my-app/src/app/profile/page.tsx
+++ b/my-app/src/app/profile/page.tsx
@@ -111,12 +111,12 @@ export default function ProfilePage() {
 
       <div className="min-h-screen bg-gray-900 pb-20">
         {/* Header */}
-        <div className="border-b border-gray-700 bg-gray-800/90 shadow-lg backdrop-blur-sm">
+        <div className="border-b border-gray-700 bg-gray-950/90 backdrop-blur-sm">
           <div className="mx-auto max-w-2xl px-4 py-4">
             <div className="flex items-center justify-between">
               <button
                 onClick={() => router.back()}
-                className="hover:text-primary-400 active:text-primary-300 text-gray-400 transition-colors"
+                className="hover:text-primary-500 active:text-primary-600 text-gray-400 transition-colors"
               >
                 <svg
                   className="size-6"
@@ -140,7 +140,7 @@ export default function ProfilePage() {
 
         {/* Content */}
         <div className="mx-auto max-w-2xl px-4 py-6">
-          <div className="rounded-lg border border-gray-700 bg-gray-800/90 p-6 shadow-xl backdrop-blur-sm">
+          <div className="rounded-lg border border-gray-700 bg-gray-950/90 p-6 backdrop-blur-sm">
             {/* Avatar Section */}
             <div className="mb-6 flex flex-col items-center">
               <div className="relative mb-4">
@@ -173,7 +173,7 @@ export default function ProfilePage() {
               <button
                 onClick={() => fileInputRef.current?.click()}
                 disabled={isUploading}
-                className="text-primary-400 hover:text-primary-300 active:text-primary-200 rounded-lg px-4 py-2 text-sm font-semibold transition-all duration-200 hover:shadow-[0_0_10px_rgba(6,182,212,0.2)] disabled:cursor-not-allowed disabled:opacity-50"
+                className="text-primary-500 hover:text-primary-400 active:text-primary-600 rounded-lg px-4 py-2 text-sm transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 {isUploading ? '上傳中...' : '更換頭像'}
               </button>
@@ -188,7 +188,7 @@ export default function ProfilePage() {
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="focus:border-primary-400 w-full rounded-md border border-gray-600 bg-gray-700/50 px-4 py-2 text-gray-100 transition-all placeholder:text-gray-500 focus:shadow-[0_0_10px_rgba(6,182,212,0.2)] focus:outline-none"
+                className="focus:border-primary-400 w-full rounded-md border border-gray-700 bg-gray-950 px-4 py-2 text-gray-100 transition-all placeholder:text-gray-500 focus:outline-none"
                 placeholder="請輸入名稱"
               />
             </div>
@@ -202,7 +202,7 @@ export default function ProfilePage() {
                 type="email"
                 value={user.email}
                 disabled
-                className="w-full cursor-not-allowed rounded-md border border-gray-700 bg-gray-800/70 px-4 py-2 text-gray-500"
+                className="w-full cursor-not-allowed rounded-md border border-gray-700 bg-gray-800 px-4 py-2 text-gray-500"
               />
             </div>
 
@@ -210,7 +210,7 @@ export default function ProfilePage() {
             <button
               onClick={handleSave}
               disabled={isSaving || isUploading}
-              className="from-primary-500 to-primary-600 mb-4 w-full rounded-md bg-linear-to-r py-3 font-semibold text-white shadow-sm transition-all hover:shadow-[0_0_20px_rgba(6,182,212,0.4)] active:shadow-[0_0_10px_rgba(6,182,212,0.3)] disabled:cursor-not-allowed disabled:opacity-50"
+              className="bg-primary-500 hover:bg-primary-400 mb-4 w-full rounded-full py-3 text-white transition-all active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
             >
               {isSaving ? '儲存中...' : '儲存變更'}
             </button>
@@ -221,7 +221,7 @@ export default function ProfilePage() {
             {/* Sign Out Button */}
             <button
               onClick={handleSignOut}
-              className="border-secondary-500 text-secondary-400 hover:bg-secondary-500/10 active:bg-secondary-500/20 w-full rounded-md border-2 py-3 font-semibold transition-all hover:shadow-[0_0_15px_rgba(139,92,246,0.3)]"
+              className="border-primary-500 text-primary-500 hover:bg-primary-50 active:bg-primary-100 w-full rounded-full border py-3 transition-all active:scale-[0.98]"
             >
               登出
             </button>

--- a/my-app/src/app/setting/UserLayer.tsx
+++ b/my-app/src/app/setting/UserLayer.tsx
@@ -27,7 +27,7 @@ function clearAllCache(): Promise<void> {
 
 const ChevronRight = () => (
   <svg
-    className="size-4 shrink-0 text-gray-600"
+    className="size-4 shrink-0 text-gray-400"
     fill="none"
     stroke="currentColor"
     viewBox="0 0 24 24"
@@ -48,7 +48,7 @@ const SectionLabel = ({ children }: { children: string }) => (
 );
 
 const RowGroup = ({ children }: { children: React.ReactNode }) => (
-  <div className="divide-y divide-white/[0.04] overflow-hidden rounded-2xl border border-white/[0.05] bg-gray-800/50">
+  <div className="divide-y divide-black/[0.06] overflow-hidden rounded-2xl border border-black/[0.06] bg-gray-950">
     {children}
   </div>
 );
@@ -86,7 +86,7 @@ export const UserLayer = () => {
       {/* ── 個人資料 ─────────────────────────────────────── */}
       <Link
         href="/profile"
-        className="group flex items-center gap-4 rounded-2xl border border-white/[0.05] bg-gray-800/50 p-4 transition-colors hover:bg-gray-800/80"
+        className="group flex items-center gap-4 rounded-2xl border border-black/[0.06] bg-gray-950 p-4 transition-colors hover:bg-gray-950"
       >
         <div className="ring-primary-500/20 size-12 shrink-0 overflow-hidden rounded-full ring-2">
           <UserAvatar user={userData} />
@@ -107,7 +107,7 @@ export const UserLayer = () => {
         <RowGroup>
           <Link
             href="/group"
-            className="flex items-center gap-3 px-4 py-3.5 transition-colors hover:bg-white/[0.03]"
+            className="flex items-center gap-3 px-4 py-3.5 transition-colors hover:bg-black/[0.03]"
           >
             <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-cyan-500/10">
               <BookIcon className="size-4 text-cyan-400" />

--- a/my-app/src/app/transactions/DailyCostChart.tsx
+++ b/my-app/src/app/transactions/DailyCostChart.tsx
@@ -59,7 +59,7 @@ export const DailyCostChart = (props: Props) => {
   const monthName = monthNames[month];
 
   return (
-    <div className="bg-background relative flex w-full flex-col items-start rounded-2xl border border-solid border-gray-700 p-6 text-gray-200 shadow-sm transition-shadow duration-200 hover:shadow">
+    <div className="bg-background relative flex w-full flex-col items-start rounded-2xl border border-solid border-gray-700 p-6 text-gray-200">
       <div className="mb-2 flex w-full items-center justify-between">
         <h3 className="text-lg font-semibold">{monthName}花費趨勢</h3>
         <Link

--- a/my-app/src/app/transactions/DailyCostChart.tsx
+++ b/my-app/src/app/transactions/DailyCostChart.tsx
@@ -14,7 +14,9 @@ interface Props {
 
 const UsageLineChart = dynamic(() => import('./UsageLineChart'), {
   ssr: false,
-  loading: () => <div className="h-64 w-full animate-pulse rounded-lg bg-gray-100"></div>
+  loading: () => (
+    <div className="h-64 w-full animate-pulse rounded-lg bg-gray-800"></div>
+  ),
 });
 
 export const DailyCostChart = (props: Props) => {
@@ -40,12 +42,25 @@ export const DailyCostChart = (props: Props) => {
   }, [costList, days]);
 
   // Get month name in Chinese
-  const monthNames = ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"];
+  const monthNames = [
+    '一月',
+    '二月',
+    '三月',
+    '四月',
+    '五月',
+    '六月',
+    '七月',
+    '八月',
+    '九月',
+    '十月',
+    '十一月',
+    '十二月',
+  ];
   const monthName = monthNames[month];
 
   return (
-    <div className="bg-background relative flex w-full flex-col items-start rounded-2xl border border-solid border-gray-300 p-6 text-gray-700 shadow-sm hover:shadow transition-shadow duration-200">
-      <div className="flex w-full items-center justify-between mb-2">
+    <div className="bg-background relative flex w-full flex-col items-start rounded-2xl border border-solid border-gray-700 p-6 text-gray-200 shadow-sm transition-shadow duration-200 hover:shadow">
+      <div className="mb-2 flex w-full items-center justify-between">
         <h3 className="text-lg font-semibold">{monthName}花費趨勢</h3>
         <Link
           href="/list"
@@ -55,7 +70,7 @@ export const DailyCostChart = (props: Props) => {
           <DoubleArrowIcon className="size-3" />
         </Link>
       </div>
-      
+
       <div className="flex w-full items-end py-4 text-xs sm:text-sm">
         <UsageLineChart
           month={month}
@@ -65,8 +80,8 @@ export const DailyCostChart = (props: Props) => {
           handleOnClick={handleSelectDataPoint}
         />
       </div>
-      
-      <div className="w-full text-xs text-gray-300 mt-2">
+
+      <div className="mt-2 w-full text-xs text-gray-300">
         點擊圖表上的點可查看當日消費明細
       </div>
     </div>

--- a/my-app/src/app/transactions/MiniDailyCostChart.tsx
+++ b/my-app/src/app/transactions/MiniDailyCostChart.tsx
@@ -63,7 +63,7 @@ export const MiniDailyCostChart = (props: Props) => {
 
   return (
     <div
-      className="relative flex w-full flex-col items-start rounded-2xl border border-white/[0.06] bg-gray-800/80 p-5 text-gray-300 shadow-md backdrop-blur-sm md:min-w-110"
+      className="relative flex w-full flex-col items-start rounded-2xl border border-black/[0.08] bg-gray-950 p-5 text-gray-300 backdrop-blur-sm md:min-w-110"
       style={{ textWrap: 'pretty' }}
     >
       <div className="flex w-full items-baseline justify-between">
@@ -95,7 +95,7 @@ export const MiniDailyCostChart = (props: Props) => {
         <div className="mt-4 w-full">
           <Accordion
             summary={(isOpen) => (
-              <div className="flex w-full items-center justify-between rounded-lg bg-gray-700/70 p-4 transition-all duration-200 hover:bg-gray-700 hover:shadow-[0_0_15px_rgba(6,182,212,0.15)]">
+              <div className="flex w-full items-center justify-between rounded-lg bg-gray-800 p-4 transition-all duration-200 hover:bg-gray-700/60">
                 <div className="flex flex-col gap-1">
                   <span className="text-sm font-medium text-gray-400">
                     {selectedDate} 的帳目
@@ -128,11 +128,11 @@ export const MiniDailyCostChart = (props: Props) => {
             defaultOpen={true}
             className="w-full"
           >
-            <div className="mt-2 flex flex-col gap-2 rounded-lg border border-gray-600 bg-gray-800/90 p-3">
+            <div className="mt-2 flex flex-col gap-2 rounded-lg border border-gray-700 bg-gray-950/90 p-3">
               {selectedDayTransactions.map((item, index) => (
                 <div
                   key={`${item.id}-${index}`}
-                  className="flex items-center justify-between rounded-lg border border-gray-700 bg-gray-700/50 p-3 text-sm transition-all duration-200 hover:bg-gray-700 hover:shadow-[0_0_10px_rgba(6,182,212,0.1)]"
+                  className="flex items-center justify-between rounded-lg border border-gray-700/60 bg-gray-900 p-3 text-sm transition-all duration-200 hover:bg-gray-800"
                 >
                   <div className="flex items-center gap-3">
                     <span className="text-xl">{item.category}</span>

--- a/my-app/src/app/transactions/Overview.tsx
+++ b/my-app/src/app/transactions/Overview.tsx
@@ -179,8 +179,8 @@ export default function OverView(props: Props) {
           href="/budget"
           className="flex items-center justify-between rounded-xl border px-3.5 py-2.5 text-sm transition-colors hover:bg-black/[0.03]"
           style={{
-            borderColor: 'rgba(248,113,113,0.25)',
-            backgroundColor: 'rgba(248,113,113,0.08)',
+            borderColor: 'rgba(227,0,0,0.25)',
+            backgroundColor: 'var(--color-over-budget-bg)',
           }}
         >
           <div className="flex items-center gap-2">

--- a/my-app/src/app/transactions/Overview.tsx
+++ b/my-app/src/app/transactions/Overview.tsx
@@ -84,7 +84,7 @@ export default function OverView(props: Props) {
 
   return (
     <div
-      className="relative flex w-full flex-col gap-5 rounded-2xl border border-white/[0.06] bg-gray-800/80 p-5 text-gray-300 shadow-md backdrop-blur-sm md:min-w-110"
+      className="relative flex w-full flex-col gap-5 rounded-2xl border border-black/[0.08] bg-gray-950 p-5 text-gray-300 backdrop-blur-sm md:min-w-110"
       style={{ textWrap: 'pretty' }}
     >
       {/* Hero — 主結餘數字 */}
@@ -97,7 +97,7 @@ export default function OverView(props: Props) {
         </span>
         <div className="flex items-baseline gap-3">
           <span
-            className="font-extrabold tabular-nums text-gray-50"
+            className="font-extrabold text-gray-50 tabular-nums"
             style={{
               fontFamily: 'var(--font-heading)',
               fontSize: 'clamp(2.25rem, 9vw, 2.625rem)', // ~36–42px
@@ -120,7 +120,7 @@ export default function OverView(props: Props) {
         </div>
 
         {/* Slim progress bar with marker */}
-        <div className="relative h-1.5 w-full overflow-visible rounded-full bg-white/[0.06]">
+        <div className="relative h-1.5 w-full overflow-visible rounded-full bg-black/[0.06]">
           <div
             className="h-full rounded-full transition-all duration-300"
             style={{
@@ -177,7 +177,7 @@ export default function OverView(props: Props) {
       {overBudgetItems.length > 0 && (
         <Link
           href="/budget"
-          className="flex items-center justify-between rounded-xl border px-3.5 py-2.5 text-sm transition-colors hover:bg-white/[0.03]"
+          className="flex items-center justify-between rounded-xl border px-3.5 py-2.5 text-sm transition-colors hover:bg-black/[0.03]"
           style={{
             borderColor: 'rgba(248,113,113,0.25)',
             backgroundColor: 'rgba(248,113,113,0.08)',
@@ -208,7 +208,7 @@ export default function OverView(props: Props) {
           <button
             type="button"
             onClick={() => setIsBudgetExpanded(!isBudgetExpanded)}
-            className="flex cursor-pointer items-center justify-between rounded-xl px-3 py-2 transition-colors hover:bg-white/[0.04]"
+            className="flex cursor-pointer items-center justify-between rounded-xl px-3 py-2 transition-colors hover:bg-black/[0.04]"
           >
             <span
               className="text-[11px] font-semibold text-gray-400"
@@ -289,7 +289,7 @@ export default function OverView(props: Props) {
                       </div>
                     </div>
 
-                    <div className="relative h-1 w-full overflow-hidden rounded-full bg-white/[0.06]">
+                    <div className="relative h-1 w-full overflow-hidden rounded-full bg-black/[0.06]">
                       <div
                         className="h-full rounded-full transition-all duration-300"
                         style={{
@@ -334,7 +334,7 @@ function Tile({
 }) {
   return (
     <div
-      className="flex flex-col gap-1 rounded-xl border border-white/[0.06] px-3.5 py-3"
+      className="flex flex-col gap-1 rounded-xl border border-black/[0.08] px-3.5 py-3"
       style={{ backgroundColor: `var(${mutedBgVar})` }}
     >
       <span

--- a/my-app/src/app/transactions/SpendingItem.tsx
+++ b/my-app/src/app/transactions/SpendingItem.tsx
@@ -51,7 +51,7 @@ export const SpendingItem = (props: Props) => {
     if (deleting) {
       return 'ring-2 ring-[var(--color-expense)]';
     }
-    return 'hover:bg-white/[0.03] cursor-pointer';
+    return 'hover:bg-black/[0.03] cursor-pointer';
   }, [deleting]);
 
   const handleOnDelete = useCallback(async () => {
@@ -93,7 +93,7 @@ export const SpendingItem = (props: Props) => {
 
   return (
     <div
-      className={`relative flex items-center gap-3 rounded-[14px] border border-white/[0.06] bg-gray-800/80 px-3 py-2.5 text-sm backdrop-blur-sm transition-colors sm:text-base ${additionalStyle} ${menuOpen ? 'z-10' : ''}`}
+      className={`relative flex items-center gap-3 rounded-[14px] border border-black/[0.08] bg-gray-950/80 px-3 py-2.5 text-sm backdrop-blur-sm transition-colors sm:text-base ${additionalStyle} ${menuOpen ? 'z-10' : ''}`}
     >
       {deleting && (
         <span
@@ -106,10 +106,10 @@ export const SpendingItem = (props: Props) => {
       {category && (
         <span
           title={CATEGORY_WORDING_MAP[category.value]}
-          className="flex size-9 items-center justify-center rounded-[10px] bg-gray-700/60"
+          className="flex size-9 items-center justify-center rounded-[10px] bg-gray-800"
           style={
             isNeed
-              ? { boxShadow: 'inset 0 0 0 1px rgba(6,182,212,0.3)' }
+              ? { boxShadow: 'inset 0 0 0 1px rgba(0,102,204,0.3)' }
               : undefined
           }
         >
@@ -157,7 +157,7 @@ export const SpendingItem = (props: Props) => {
               label: (
                 <Link
                   href={`/edit?id=${spending.id}`}
-                  className="group-hover:text-primary-400 group-active:text-primary-300 flex items-center gap-3 text-gray-300 transition-colors"
+                  className="group-hover:text-primary-500 group-active:text-primary-600 flex items-center gap-3 text-gray-300 transition-colors"
                 >
                   <EditIcon className="size-4 transition-colors sm:size-4" />
                   <span className="font-medium">編輯</span>

--- a/my-app/src/app/transactions/UsageLineChart.tsx
+++ b/my-app/src/app/transactions/UsageLineChart.tsx
@@ -85,7 +85,7 @@ const CustomToolTip = (props: DefaultTooltipContentProps<string, string>) => {
   return (
     <div className="bg-background flex flex-col rounded p-2 text-xs shadow">
       <span
-        className="text-primary-300"
+        className="text-primary-500"
         style={{ fontVariantNumeric: 'tabular-nums' }}
       >
         花費：${normalizeNumber(payload.cost)}

--- a/my-app/src/components/ActionMenu.tsx
+++ b/my-app/src/components/ActionMenu.tsx
@@ -43,7 +43,7 @@ export const ActionMenu = (props: Props) => {
         ref={buttonRef}
         type="button"
         onClick={handleToggle}
-        className={`flex min-h-11 min-w-11 items-center justify-center rounded-full p-2 transition-all duration-200 ${open ? 'bg-primary-500/20 text-primary-400 shadow-[0_0_15px_rgba(6,182,212,0.3)]' : 'text-gray-400 hover:bg-gray-700/70 hover:shadow-[0_0_10px_rgba(6,182,212,0.2)] active:bg-gray-600/70'}`}
+        className={`flex min-h-11 min-w-11 items-center justify-center rounded-full p-2 transition-all duration-200 ${open ? 'bg-primary-50 text-primary-500' : 'text-gray-400 hover:bg-gray-800 active:bg-gray-700/60'}`}
         aria-label="Open action menu"
         aria-expanded={open}
       >
@@ -51,7 +51,7 @@ export const ActionMenu = (props: Props) => {
       </button>
       <div
         ref={menuRef}
-        className={`absolute right-0 z-30 flex w-fit flex-col rounded-xl border border-gray-600 bg-gray-800 p-2 shadow-xl backdrop-blur-sm transition-all duration-200 ${openAbove ? 'bottom-full mb-2' : 'top-full mt-2'} ${open ? 'scale-100 opacity-100' : 'hidden scale-95 opacity-0'}`}
+        className={`absolute right-0 z-30 flex w-fit flex-col rounded-xl border border-gray-700 bg-gray-950 p-2 shadow-lg backdrop-blur-sm transition-all duration-200 ${openAbove ? 'bottom-full mb-2' : 'top-full mt-2'} ${open ? 'scale-100 opacity-100' : 'hidden scale-95 opacity-0'}`}
       >
         {options.map((option) => (
           <button
@@ -60,7 +60,7 @@ export const ActionMenu = (props: Props) => {
             onClick={() => {
               if (onClick) onClick(option.value);
             }}
-            className={`group hover:text-primary-400 flex min-h-11 cursor-pointer items-center gap-2 rounded-lg px-4 py-3 whitespace-nowrap transition-all duration-200 hover:bg-gray-700/70 hover:shadow-[0_0_10px_rgba(6,182,212,0.2)] active:bg-gray-600/70 ${option.className ?? ''}`}
+            className={`group hover:text-primary-500 flex min-h-11 cursor-pointer items-center gap-2 rounded-lg px-4 py-3 whitespace-nowrap transition-all duration-200 hover:bg-gray-800 active:bg-gray-700/60 ${option.className ?? ''}`}
           >
             {option.label}
           </button>

--- a/my-app/src/components/ImageCropper.tsx
+++ b/my-app/src/components/ImageCropper.tsx
@@ -10,7 +10,11 @@ interface ImageCropperProps {
   onCancel: () => void;
 }
 
-export function ImageCropper({ image, onCropComplete, onCancel }: ImageCropperProps) {
+export function ImageCropper({
+  image,
+  onCropComplete,
+  onCancel,
+}: ImageCropperProps) {
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
@@ -27,7 +31,7 @@ export function ImageCropper({ image, onCropComplete, onCancel }: ImageCropperPr
     (croppedArea: Area, croppedAreaPixels: Area) => {
       setCroppedAreaPixels(croppedAreaPixels);
     },
-    []
+    [],
   );
 
   const createImage = (url: string): Promise<HTMLImageElement> =>
@@ -40,7 +44,7 @@ export function ImageCropper({ image, onCropComplete, onCancel }: ImageCropperPr
 
   const getCroppedImg = async (
     imageSrc: string,
-    pixelCrop: Area
+    pixelCrop: Area,
   ): Promise<string> => {
     const image = await createImage(imageSrc);
     const canvas = document.createElement('canvas');
@@ -62,7 +66,7 @@ export function ImageCropper({ image, onCropComplete, onCancel }: ImageCropperPr
       0,
       0,
       pixelCrop.width,
-      pixelCrop.height
+      pixelCrop.height,
     );
 
     return new Promise((resolve) => {
@@ -93,11 +97,8 @@ export function ImageCropper({ image, onCropComplete, onCancel }: ImageCropperPr
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-black">
       {/* Header */}
-      <div className="flex items-center justify-between bg-gray-900 px-4 py-3">
-        <button
-          onClick={onCancel}
-          className="text-white hover:text-gray-300"
-        >
+      <div className="flex items-center justify-between bg-black px-4 py-3">
+        <button onClick={onCancel} className="text-white hover:text-white/70">
           取消
         </button>
         <h2 className="text-lg font-semibold text-white">裁剪圖片</h2>
@@ -125,7 +126,7 @@ export function ImageCropper({ image, onCropComplete, onCancel }: ImageCropperPr
       </div>
 
       {/* Zoom Control */}
-      <div className="bg-gray-900 px-6 py-4">
+      <div className="bg-black px-6 py-4">
         <div className="flex items-center gap-4">
           <span className="text-sm text-white">縮放</span>
           <input

--- a/my-app/src/components/InputBox.tsx
+++ b/my-app/src/components/InputBox.tsx
@@ -9,7 +9,7 @@ interface Props extends HTMLAttributes<HTMLInputElement> {
 export const InputBox = (props: Props) => {
   const { className = '', type, name, label, ...legacy } = props;
   return (
-    <fieldset className="hover:border-primary-600 focus-within:border-primary-500 focus-within:shadow-[0_0_15px_rgba(6,182,212,0.15)] rounded-xl border-2 border-solid border-gray-700 bg-gray-900/40 px-3 pb-2 transition-all duration-200">
+    <fieldset className="hover:border-primary-400 focus-within:border-primary-500 rounded-xl border border-solid border-gray-700 bg-gray-950 px-3 pb-2 transition-all duration-200">
       <legend className="px-2 text-sm font-medium text-gray-400">
         {label}
       </legend>

--- a/my-app/src/components/Modal.tsx
+++ b/my-app/src/components/Modal.tsx
@@ -53,19 +53,19 @@ export const Modal = forwardRef<ModalRef, Props>((props, ref) => {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm sm:p-4">
       <div
         ref={contentRef}
-        className={`animate-modal relative flex w-full max-w-2xl flex-col self-end rounded-2xl border border-gray-700 bg-gray-800 shadow-2xl sm:max-w-96 sm:self-center sm:rounded-xl max-h-[90dvh] ${props.className}`}
+        className={`animate-modal relative flex max-h-[90dvh] w-full max-w-2xl flex-col self-end rounded-2xl border border-gray-700 bg-gray-950 shadow-xl sm:max-w-96 sm:self-center sm:rounded-xl ${props.className}`}
       >
         <button
           type="button"
           onClick={handleCloseModal}
-          className="hover:text-primary-400 focus-visible:outline-primary-400 absolute top-4 right-4 z-10 size-6 rounded-full bg-gray-700/90 p-2 text-gray-400 backdrop-blur-sm transition-all duration-200 hover:bg-gray-600 hover:shadow-[0_0_15px_rgba(6,182,212,0.3)]"
+          className="focus-visible:outline-primary-400 absolute top-4 right-4 z-10 size-6 rounded-full bg-[rgba(210,210,215,0.64)] p-2 text-gray-200 backdrop-blur-sm transition-all duration-200 hover:bg-gray-600 active:scale-95"
           aria-label="Close modal"
         >
           <CloseIcon className="size-full" />
         </button>
-        <div className="from-primary-500 to-accent-500 rounded-t-2xl bg-linear-to-r px-5 py-4 text-white sm:rounded-t-xl">
+        <div className="rounded-t-2xl border-b border-gray-700 bg-gray-950 px-5 py-4 text-gray-100 sm:rounded-t-xl">
           <h3
-            className="pr-12 text-base font-bold sm:text-lg"
+            className="pr-12 text-base font-semibold sm:text-lg"
             style={{ fontFamily: 'var(--font-heading)' }}
           >
             {props.title}

--- a/my-app/src/components/NumberKeyboard.tsx
+++ b/my-app/src/components/NumberKeyboard.tsx
@@ -41,30 +41,72 @@ export const NumberKeyboard = ({ value, onChange }: Props) => {
       }}
     >
       {/* row 1: 7 8 9 ⌫ */}
-      <Key value="7" onPress={press} style={{ gridRow: 1, gridColumn: 1 }}>7</Key>
-      <Key value="8" onPress={press} style={{ gridRow: 1, gridColumn: 2 }}>8</Key>
-      <Key value="9" onPress={press} style={{ gridRow: 1, gridColumn: 3 }}>9</Key>
-      <Key value="delete" variant="delete" onPress={press} style={{ gridRow: 1, gridColumn: 4 }}>
+      <Key value="7" onPress={press} style={{ gridRow: 1, gridColumn: 1 }}>
+        7
+      </Key>
+      <Key value="8" onPress={press} style={{ gridRow: 1, gridColumn: 2 }}>
+        8
+      </Key>
+      <Key value="9" onPress={press} style={{ gridRow: 1, gridColumn: 3 }}>
+        9
+      </Key>
+      <Key
+        value="delete"
+        variant="delete"
+        onPress={press}
+        style={{ gridRow: 1, gridColumn: 4 }}
+      >
         <BackspaceIcon className="size-5" />
       </Key>
 
       {/* row 2: 4 5 6 . */}
-      <Key value="4" onPress={press} style={{ gridRow: 2, gridColumn: 1 }}>4</Key>
-      <Key value="5" onPress={press} style={{ gridRow: 2, gridColumn: 2 }}>5</Key>
-      <Key value="6" onPress={press} style={{ gridRow: 2, gridColumn: 3 }}>6</Key>
+      <Key value="4" onPress={press} style={{ gridRow: 2, gridColumn: 1 }}>
+        4
+      </Key>
+      <Key value="5" onPress={press} style={{ gridRow: 2, gridColumn: 2 }}>
+        5
+      </Key>
+      <Key value="6" onPress={press} style={{ gridRow: 2, gridColumn: 3 }}>
+        6
+      </Key>
       <Key value="." onPress={press} style={{ gridRow: 2, gridColumn: 4 }}>
         <span className="text-2xl leading-none">·</span>
       </Key>
 
       {/* row 3: 1 2 3 C */}
-      <Key value="1" onPress={press} style={{ gridRow: 3, gridColumn: 1 }}>1</Key>
-      <Key value="2" onPress={press} style={{ gridRow: 3, gridColumn: 2 }}>2</Key>
-      <Key value="3" onPress={press} style={{ gridRow: 3, gridColumn: 3 }}>3</Key>
-      <Key value="clear" variant="clear" onPress={press} style={{ gridRow: 3, gridColumn: 4 }}>C</Key>
+      <Key value="1" onPress={press} style={{ gridRow: 3, gridColumn: 1 }}>
+        1
+      </Key>
+      <Key value="2" onPress={press} style={{ gridRow: 3, gridColumn: 2 }}>
+        2
+      </Key>
+      <Key value="3" onPress={press} style={{ gridRow: 3, gridColumn: 3 }}>
+        3
+      </Key>
+      <Key
+        value="clear"
+        variant="clear"
+        onPress={press}
+        style={{ gridRow: 3, gridColumn: 4 }}
+      >
+        C
+      </Key>
 
       {/* row 4: 0 (wide) 00 (wide) */}
-      <Key value="0" onPress={press} style={{ gridRow: 4, gridColumn: '1 / span 2' }}>0</Key>
-      <Key value="00" onPress={press} style={{ gridRow: 4, gridColumn: '3 / span 2' }}>00</Key>
+      <Key
+        value="0"
+        onPress={press}
+        style={{ gridRow: 4, gridColumn: '1 / span 2' }}
+      >
+        0
+      </Key>
+      <Key
+        value="00"
+        onPress={press}
+        style={{ gridRow: 4, gridColumn: '3 / span 2' }}
+      >
+        00
+      </Key>
     </div>
   );
 };
@@ -87,8 +129,8 @@ const Key = ({
 }) => {
   const variantClass =
     variant === 'delete'
-      ? 'bg-white/[0.04] text-[var(--color-expense)] border border-white/[0.06]'
-      : 'bg-white/[0.04] text-gray-100 border border-white/[0.06]';
+      ? 'bg-black/[0.04] text-[var(--color-expense)] border border-black/[0.08]'
+      : 'bg-black/[0.04] text-gray-100 border border-black/[0.08]';
 
   return (
     <button

--- a/my-app/src/components/QuickNavigationCards.tsx
+++ b/my-app/src/components/QuickNavigationCards.tsx
@@ -12,28 +12,24 @@ const NAVIGATION_CARDS = [
     description: '詳細收支記錄',
     href: '/transactions',
     icon: ListTaskIcon,
-    gradient: 'from-primary-400 to-secondary-400',
   },
   {
     title: '帳本管理',
     description: '管理帳本與成員',
     href: '/group',
     icon: BookIcon,
-    gradient: 'from-secondary-400 to-secondary-600',
   },
   {
     title: '帳目分析',
     description: '查看消費統計圖表',
     href: '/analysis',
     icon: BarChartIcon,
-    gradient: 'from-accent-400 to-accent-600',
   },
   {
     title: '預算管理',
     description: '設定與管理預算',
     href: '/budget',
     icon: CoinIcon,
-    gradient: 'from-income-400 to-income-600',
   },
 ];
 
@@ -46,12 +42,10 @@ export const QuickNavigationCards = ({ isMobile }: { isMobile: boolean }) => {
           <Link
             key={card.href}
             href={card.href}
-            className="card group relative flex min-h-30 cursor-pointer flex-col items-center justify-center gap-3 p-5 transition-all duration-200 hover:shadow-[0_0_20px_rgba(6,182,212,0.25)]"
+            className="card group relative flex min-h-30 cursor-pointer flex-col items-center justify-center gap-3 p-5 transition-all duration-200 active:scale-[0.98]"
           >
-            <div
-              className={`flex items-center justify-center rounded-2xl bg-linear-to-r ${card.gradient} p-4 shadow-lg transition-all duration-200 group-hover:shadow-[0_0_20px_rgba(6,182,212,0.4)]`}
-            >
-              <Icon className="size-7 text-white" />
+            <div className="bg-primary-50 flex items-center justify-center rounded-2xl p-4 transition-all duration-200">
+              <Icon className="text-primary-500 size-7" />
             </div>
             <div className="flex flex-col items-center gap-1">
               <h3

--- a/my-app/src/components/RecentTransactionsList.tsx
+++ b/my-app/src/components/RecentTransactionsList.tsx
@@ -25,7 +25,7 @@ export const RecentTransactionsList = ({
   // Only show loading skeleton if we have no data yet
   if (loading && data.length === 0) {
     return (
-      <div className="flex w-full flex-col rounded-2xl border border-white/[0.06] bg-gray-800/80 p-5 shadow-md backdrop-blur-sm md:min-w-110">
+      <div className="flex w-full flex-col rounded-2xl border border-black/[0.08] bg-gray-950 p-5 backdrop-blur-sm md:min-w-110">
         <h3
           className="mb-4 text-base font-bold text-gray-100"
           style={{ fontFamily: 'var(--font-heading)' }}
@@ -42,7 +42,7 @@ export const RecentTransactionsList = ({
   }
 
   return (
-    <div className="flex w-full flex-col rounded-2xl border border-white/[0.06] bg-gray-800/80 p-5 shadow-md backdrop-blur-sm md:min-w-110">
+    <div className="flex w-full flex-col rounded-2xl border border-black/[0.08] bg-gray-950 p-5 backdrop-blur-sm md:min-w-110">
       <div className="mb-4 flex items-center justify-between">
         <h3
           className="text-base font-bold text-gray-100"
@@ -52,7 +52,7 @@ export const RecentTransactionsList = ({
         </h3>
         <Link
           href="/transactions"
-          className="text-primary-400 hover:text-primary-300 active:text-primary-200 flex items-center gap-1 text-xs font-bold transition-colors"
+          className="text-primary-500 hover:text-primary-400 active:text-primary-600 flex items-center gap-1 text-xs font-bold transition-colors"
         >
           查看更多
           <DoubleArrowIcon className="size-3" />

--- a/my-app/src/components/Select.tsx
+++ b/my-app/src/components/Select.tsx
@@ -120,7 +120,7 @@ export const Select = (props: Props) => {
           />
         </button>
         <div
-          className={`fixed z-[9999] overflow-hidden rounded-xl border-2 border-solid border-gray-600 bg-gray-800 py-1 shadow-xl backdrop-blur-sm transition-all duration-200 ${openOptions ? 'visible scale-100 opacity-100' : 'invisible scale-95 opacity-0'}`}
+          className={`fixed z-[9999] overflow-hidden rounded-xl border border-solid border-gray-700 bg-gray-950 py-1 shadow-lg backdrop-blur-sm transition-all duration-200 ${openOptions ? 'visible scale-100 opacity-100' : 'invisible scale-95 opacity-0'}`}
           style={{
             ...dropdownStyle,
             maxHeight: menuMaxHeight,
@@ -168,7 +168,7 @@ const Item = ({
         onChange(value);
         close();
       }}
-      className={`flex min-h-11 w-full cursor-pointer px-4 py-3 transition-all duration-200 ${className} ${current === value ? 'bg-primary-500/20 text-primary-400 font-semibold shadow-[0_0_10px_rgba(6,182,212,0.2)]' : 'hover:text-primary-400 text-gray-300 hover:bg-gray-700/70 hover:shadow-[0_0_8px_rgba(6,182,212,0.15)] active:bg-gray-700'}`}
+      className={`flex min-h-11 w-full cursor-pointer px-4 py-3 transition-all duration-200 ${className} ${current === value ? 'bg-primary-50 text-primary-500 font-semibold' : 'hover:text-primary-500 text-gray-300 hover:bg-gray-800 active:bg-gray-700/60'}`}
     >
       <span className="overflow-hidden text-left text-ellipsis whitespace-nowrap">
         {children}
@@ -200,7 +200,9 @@ const calVerticalDirection = (element: HTMLDivElement) => {
   const { top, bottom } = getContainerBounds(element);
   const spaceBelow = bottom - rect.bottom;
   const spaceAbove = rect.top - top;
-  return spaceBelow >= spaceAbove ? MenuOpenDirection.Down : MenuOpenDirection.Up;
+  return spaceBelow >= spaceAbove
+    ? MenuOpenDirection.Down
+    : MenuOpenDirection.Up;
 };
 
 const calHorizontalDirection = (element: HTMLDivElement) => {

--- a/my-app/src/components/skeletons/AnalysisSkeleton.tsx
+++ b/my-app/src/components/skeletons/AnalysisSkeleton.tsx
@@ -2,18 +2,18 @@ export const AnalysisSkeleton = () => {
   return (
     <div className="content-wrapper animate-pulse">
       {/* Year/Month Filter Skeleton */}
-      <div className="flex self-center rounded-lg border border-gray-200 bg-gray-100 p-2 shadow-sm h-10 w-64"></div>
+      <div className="flex h-10 w-64 self-center rounded-lg border border-gray-700 bg-gray-800 p-2 shadow-sm"></div>
 
       {/* Chart Blocks - Income vs Expense */}
       <div className="flex w-full flex-col items-center gap-8 md:flex-row md:items-start">
-        <div className="bg-background w-full rounded-2xl border border-solid border-gray-200 p-6 shadow-sm">
-          <div className="h-6 w-36 bg-gray-200 rounded mb-4"></div>
+        <div className="bg-background w-full rounded-2xl border border-solid border-gray-700 p-6 shadow-sm">
+          <div className="mb-4 h-6 w-36 rounded bg-gray-700"></div>
           <div className="flex w-full flex-wrap justify-center gap-4">
             {/* Pie Chart */}
             <div className="size-75">
-              <div className="mx-auto aspect-square rounded-full bg-gray-100 p-1.5">
+              <div className="mx-auto aspect-square rounded-full bg-gray-800 p-1.5">
                 <div className="bg-background size-full rounded-full p-1.5">
-                  <div className="size-full rounded-full bg-gray-100 p-5">
+                  <div className="size-full rounded-full bg-gray-800 p-5">
                     <div className="bg-background size-full rounded-full"></div>
                   </div>
                 </div>
@@ -23,9 +23,12 @@ export const AnalysisSkeleton = () => {
             <div className="flex flex-1 flex-col gap-4">
               <div className="flex flex-col gap-2">
                 {[1, 2, 3, 4].map((i) => (
-                  <div key={i} className="flex items-center justify-between py-2">
-                    <div className="h-4 w-24 bg-gray-200 rounded"></div>
-                    <div className="h-4 w-20 bg-gray-200 rounded"></div>
+                  <div
+                    key={i}
+                    className="flex items-center justify-between py-2"
+                  >
+                    <div className="h-4 w-24 rounded bg-gray-700"></div>
+                    <div className="h-4 w-20 rounded bg-gray-700"></div>
                   </div>
                 ))}
               </div>
@@ -34,14 +37,14 @@ export const AnalysisSkeleton = () => {
         </div>
 
         {/* Necessity Chart Block */}
-        <div className="bg-background w-full rounded-2xl border border-solid border-gray-200 p-6 shadow-sm">
-          <div className="h-6 w-48 bg-gray-200 rounded mb-4"></div>
+        <div className="bg-background w-full rounded-2xl border border-solid border-gray-700 p-6 shadow-sm">
+          <div className="mb-4 h-6 w-48 rounded bg-gray-700"></div>
           <div className="flex w-full flex-wrap justify-center gap-4">
             {/* Pie Chart */}
             <div className="size-75">
-              <div className="mx-auto aspect-square rounded-full bg-gray-100 p-1.5">
+              <div className="mx-auto aspect-square rounded-full bg-gray-800 p-1.5">
                 <div className="bg-background size-full rounded-full p-1.5">
-                  <div className="size-full rounded-full bg-gray-100 p-5">
+                  <div className="size-full rounded-full bg-gray-800 p-5">
                     <div className="bg-background size-full rounded-full"></div>
                   </div>
                 </div>
@@ -51,9 +54,12 @@ export const AnalysisSkeleton = () => {
             <div className="flex flex-1 flex-col gap-4">
               <div className="flex flex-col gap-2">
                 {[1, 2, 3, 4].map((i) => (
-                  <div key={i} className="flex items-center justify-between py-2">
-                    <div className="h-4 w-24 bg-gray-200 rounded"></div>
-                    <div className="h-4 w-20 bg-gray-200 rounded"></div>
+                  <div
+                    key={i}
+                    className="flex items-center justify-between py-2"
+                  >
+                    <div className="h-4 w-24 rounded bg-gray-700"></div>
+                    <div className="h-4 w-20 rounded bg-gray-700"></div>
                   </div>
                 ))}
               </div>
@@ -64,14 +70,14 @@ export const AnalysisSkeleton = () => {
 
       {/* Budget Analysis Section (optional) */}
       <div className="flex w-full flex-col items-center gap-8 md:flex-row md:items-start">
-        <div className="bg-background w-full rounded-2xl border border-solid border-gray-200 p-6 shadow-sm">
-          <div className="h-6 w-56 bg-gray-200 rounded mb-4"></div>
+        <div className="bg-background w-full rounded-2xl border border-solid border-gray-700 p-6 shadow-sm">
+          <div className="mb-4 h-6 w-56 rounded bg-gray-700"></div>
           <div className="flex w-full flex-wrap justify-center gap-4">
             {/* Pie Chart */}
             <div className="size-75">
-              <div className="mx-auto aspect-square rounded-full bg-gray-100 p-1.5">
+              <div className="mx-auto aspect-square rounded-full bg-gray-800 p-1.5">
                 <div className="bg-background size-full rounded-full p-1.5">
-                  <div className="size-full rounded-full bg-gray-100 p-5">
+                  <div className="size-full rounded-full bg-gray-800 p-5">
                     <div className="bg-background size-full rounded-full"></div>
                   </div>
                 </div>
@@ -81,9 +87,12 @@ export const AnalysisSkeleton = () => {
             <div className="flex flex-1 flex-col gap-4">
               <div className="flex flex-col gap-2">
                 {[1, 2, 3, 4].map((i) => (
-                  <div key={i} className="flex items-center justify-between py-2">
-                    <div className="h-4 w-24 bg-gray-200 rounded"></div>
-                    <div className="h-4 w-20 bg-gray-200 rounded"></div>
+                  <div
+                    key={i}
+                    className="flex items-center justify-between py-2"
+                  >
+                    <div className="h-4 w-24 rounded bg-gray-700"></div>
+                    <div className="h-4 w-20 rounded bg-gray-700"></div>
                   </div>
                 ))}
               </div>

--- a/my-app/src/components/skeletons/BudgetSkeleton.tsx
+++ b/my-app/src/components/skeletons/BudgetSkeleton.tsx
@@ -5,42 +5,45 @@ export const BudgetSkeleton = () => {
       <div className="grid w-full grid-cols-1 gap-3 md:max-w-250 md:grid-cols-2 md:gap-5">
         {/* Annual Budget Section Skeleton */}
         <div className="bg-background w-full rounded-xl p-6 shadow">
-          <div className="h-6 w-24 bg-gray-200 rounded"></div>
+          <div className="h-6 w-24 rounded bg-gray-700"></div>
           <div className="mt-4">
-            <div className="h-9 w-40 bg-gray-200 rounded"></div>
-            <div className="h-4 w-28 bg-gray-200 rounded mt-1"></div>
-            <div className="mt-2 h-2 w-full rounded-full bg-gray-200"></div>
-            <div className="h-4 w-48 bg-gray-200 rounded mt-2"></div>
+            <div className="h-9 w-40 rounded bg-gray-700"></div>
+            <div className="mt-1 h-4 w-28 rounded bg-gray-700"></div>
+            <div className="mt-2 h-2 w-full rounded-full bg-gray-700"></div>
+            <div className="mt-2 h-4 w-48 rounded bg-gray-700"></div>
           </div>
         </div>
 
         {/* Monthly Budget Section Skeleton */}
         <div className="bg-background w-full rounded-xl p-6 shadow">
-          <div className="h-6 w-24 bg-gray-200 rounded"></div>
+          <div className="h-6 w-24 rounded bg-gray-700"></div>
           <div className="mt-4">
-            <div className="h-9 w-40 bg-gray-200 rounded"></div>
-            <div className="h-4 w-36 bg-gray-200 rounded mt-1"></div>
-            <div className="mt-2 h-2 w-full rounded-full bg-gray-200"></div>
-            <div className="h-4 w-48 bg-gray-200 rounded mt-2"></div>
+            <div className="h-9 w-40 rounded bg-gray-700"></div>
+            <div className="mt-1 h-4 w-36 rounded bg-gray-700"></div>
+            <div className="mt-2 h-2 w-full rounded-full bg-gray-700"></div>
+            <div className="mt-2 h-4 w-48 rounded bg-gray-700"></div>
           </div>
         </div>
       </div>
 
       {/* Monthly Budget Blocks Skeleton */}
-      <div className="bg-background flex w-full flex-col gap-4 rounded-2xl border border-solid border-gray-200 p-6 shadow-sm">
-        <div className="h-6 w-32 bg-gray-200 rounded"></div>
+      <div className="bg-background flex w-full flex-col gap-4 rounded-2xl border border-solid border-gray-700 p-6 shadow-sm">
+        <div className="h-6 w-32 rounded bg-gray-700"></div>
 
         {/* Monthly Blocks Grid */}
         <div className="grid grid-cols-2 gap-3 md:grid-cols-4 lg:grid-cols-6">
           {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((i) => (
             <div
               key={i}
-              className="flex flex-col gap-2 rounded-lg border border-gray-200 bg-gray-50 p-3"
+              className="flex flex-col gap-2 rounded-lg border border-gray-700 bg-gray-50 p-3"
             >
-              <div className="h-4 w-16 bg-gray-200 rounded"></div>
-              <div className="h-6 w-20 bg-gray-200 rounded"></div>
-              <div className="h-2 w-full bg-gray-100 rounded-full mt-1">
-                <div className="h-2 bg-gray-200 rounded-full" style={{ width: '60%' }}></div>
+              <div className="h-4 w-16 rounded bg-gray-700"></div>
+              <div className="h-6 w-20 rounded bg-gray-700"></div>
+              <div className="mt-1 h-2 w-full rounded-full bg-gray-800">
+                <div
+                  className="h-2 rounded-full bg-gray-700"
+                  style={{ width: '60%' }}
+                ></div>
               </div>
             </div>
           ))}
@@ -51,14 +54,14 @@ export const BudgetSkeleton = () => {
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
-              className="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3"
+              className="flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-50 p-3"
             >
-              <div className="size-6 bg-gray-200 rounded"></div>
+              <div className="size-6 rounded bg-gray-700"></div>
               <div className="flex-1">
-                <div className="h-4 w-32 bg-gray-200 rounded mb-1"></div>
-                <div className="h-3 w-24 bg-gray-200 rounded"></div>
+                <div className="mb-1 h-4 w-32 rounded bg-gray-700"></div>
+                <div className="h-3 w-24 rounded bg-gray-700"></div>
               </div>
-              <div className="h-5 w-20 bg-gray-200 rounded"></div>
+              <div className="h-5 w-20 rounded bg-gray-700"></div>
             </div>
           ))}
         </div>

--- a/my-app/src/components/skeletons/BudgetSkeleton.tsx
+++ b/my-app/src/components/skeletons/BudgetSkeleton.tsx
@@ -35,7 +35,7 @@ export const BudgetSkeleton = () => {
           {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((i) => (
             <div
               key={i}
-              className="flex flex-col gap-2 rounded-lg border border-gray-700 bg-gray-50 p-3"
+              className="flex flex-col gap-2 rounded-lg border border-gray-700 bg-gray-800 p-3"
             >
               <div className="h-4 w-16 rounded bg-gray-700"></div>
               <div className="h-6 w-20 rounded bg-gray-700"></div>
@@ -54,7 +54,7 @@ export const BudgetSkeleton = () => {
           {[1, 2, 3, 4, 5].map((i) => (
             <div
               key={i}
-              className="flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-50 p-3"
+              className="flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 p-3"
             >
               <div className="size-6 rounded bg-gray-700"></div>
               <div className="flex-1">

--- a/my-app/src/components/skeletons/DashboardSkeleton.tsx
+++ b/my-app/src/components/skeletons/DashboardSkeleton.tsx
@@ -25,7 +25,7 @@ export const DashboardSkeleton = () => {
             {[1, 2, 3].map((i) => (
               <div
                 key={i}
-                className="flex flex-col gap-1 rounded-lg bg-gray-50 p-3"
+                className="flex flex-col gap-1 rounded-lg bg-gray-800 p-3"
               >
                 <div className="h-3 w-12 rounded bg-gray-700"></div>
                 <div className="h-5 w-20 rounded bg-gray-700"></div>
@@ -74,7 +74,7 @@ export const DashboardSkeleton = () => {
             {[1, 2, 3, 4, 5].map((i) => (
               <div
                 key={i}
-                className="flex items-center gap-3 rounded-lg bg-gray-50 p-3"
+                className="flex items-center gap-3 rounded-lg bg-gray-800 p-3"
               >
                 <div className="size-6 rounded bg-gray-700"></div>
                 <div className="flex-1">

--- a/my-app/src/components/skeletons/DashboardSkeleton.tsx
+++ b/my-app/src/components/skeletons/DashboardSkeleton.tsx
@@ -2,51 +2,54 @@ export const DashboardSkeleton = () => {
   return (
     <div className="content-wrapper animate-pulse">
       {/* Year/Month Filter Skeleton */}
-      <div className="flex justify-center rounded-lg border border-gray-200 bg-gray-100 p-2 shadow-sm h-10 w-64"></div>
+      <div className="flex h-10 w-64 justify-center rounded-lg border border-gray-700 bg-gray-800 p-2 shadow-sm"></div>
 
       <div className="flex w-full flex-col gap-3 md:w-auto md:flex-row md:items-start md:gap-5">
         {/* Overview Card Skeleton */}
-        <div className="bg-background relative flex w-full flex-col gap-5 rounded-2xl border border-solid border-gray-300 p-6 shadow-sm md:min-w-110">
+        <div className="bg-background relative flex w-full flex-col gap-5 rounded-2xl border border-solid border-gray-700 p-6 shadow-sm md:min-w-110">
           {/* Header with primary metric */}
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2">
-              <div className="size-5 bg-gray-200 rounded"></div>
-              <div className="h-4 w-28 bg-gray-200 rounded"></div>
+              <div className="size-5 rounded bg-gray-700"></div>
+              <div className="h-4 w-28 rounded bg-gray-700"></div>
             </div>
-            <div className="h-10 w-48 bg-gray-200 rounded"></div>
-            <div className="h-2.5 w-full bg-gray-100 rounded-full"></div>
+            <div className="h-10 w-48 rounded bg-gray-700"></div>
+            <div className="h-2.5 w-full rounded-full bg-gray-800"></div>
             <div className="flex items-center justify-between">
-              <div className="h-3 w-24 bg-gray-200 rounded"></div>
+              <div className="h-3 w-24 rounded bg-gray-700"></div>
             </div>
           </div>
 
           {/* Financial breakdown grid */}
           <div className="grid grid-cols-3 gap-3">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="flex flex-col gap-1 rounded-lg bg-gray-50 p-3">
-                <div className="h-3 w-12 bg-gray-200 rounded"></div>
-                <div className="h-5 w-20 bg-gray-200 rounded"></div>
+              <div
+                key={i}
+                className="flex flex-col gap-1 rounded-lg bg-gray-50 p-3"
+              >
+                <div className="h-3 w-12 rounded bg-gray-700"></div>
+                <div className="h-5 w-20 rounded bg-gray-700"></div>
               </div>
             ))}
           </div>
 
           {/* Budget usage accordion header (collapsed) */}
           <div className="flex items-center justify-between rounded-lg px-2 py-2">
-            <div className="h-3 w-24 bg-gray-200 rounded"></div>
-            <div className="size-4 bg-gray-200 rounded"></div>
+            <div className="h-3 w-24 rounded bg-gray-700"></div>
+            <div className="size-4 rounded bg-gray-700"></div>
           </div>
 
           {/* Action button */}
-          <div className="h-10 w-full bg-gray-700 rounded-lg"></div>
+          <div className="h-10 w-full rounded-lg bg-gray-700"></div>
         </div>
 
         {/* Daily Cost Chart Skeleton */}
-        <div className="bg-background relative flex w-full flex-col items-start rounded-2xl border border-solid border-gray-200 p-6 shadow-sm">
-          <div className="flex w-full items-center justify-between mb-2">
-            <div className="h-6 w-24 bg-gray-200 rounded"></div>
-            <div className="h-4 w-16 bg-gray-200 rounded"></div>
+        <div className="bg-background relative flex w-full flex-col items-start rounded-2xl border border-solid border-gray-700 p-6 shadow-sm">
+          <div className="mb-2 flex w-full items-center justify-between">
+            <div className="h-6 w-24 rounded bg-gray-700"></div>
+            <div className="h-4 w-16 rounded bg-gray-700"></div>
           </div>
-          <div className="w-full h-48 bg-gray-100 rounded-lg"></div>
+          <div className="h-48 w-full rounded-lg bg-gray-800"></div>
         </div>
       </div>
 
@@ -56,26 +59,29 @@ export const DashboardSkeleton = () => {
           {[1, 2, 3, 4].map((i) => (
             <div
               key={i}
-              className="bg-background flex min-h-24 flex-col items-center justify-center gap-2 rounded-2xl border border-solid border-gray-200 p-4 shadow-sm"
+              className="bg-background flex min-h-24 flex-col items-center justify-center gap-2 rounded-2xl border border-solid border-gray-700 p-4 shadow-sm"
             >
-              <div className="size-8 bg-gray-200 rounded-full"></div>
-              <div className="h-4 w-20 bg-gray-200 rounded"></div>
+              <div className="size-8 rounded-full bg-gray-700"></div>
+              <div className="h-4 w-20 rounded bg-gray-700"></div>
             </div>
           ))}
         </div>
 
         {/* Recent Transactions Skeleton */}
-        <div className="bg-background flex w-full flex-col rounded-2xl border border-solid border-gray-200 p-6 shadow-sm">
-          <div className="h-6 w-32 bg-gray-200 rounded mb-4"></div>
+        <div className="bg-background flex w-full flex-col rounded-2xl border border-solid border-gray-700 p-6 shadow-sm">
+          <div className="mb-4 h-6 w-32 rounded bg-gray-700"></div>
           <div className="flex flex-col gap-2">
             {[1, 2, 3, 4, 5].map((i) => (
-              <div key={i} className="flex items-center gap-3 rounded-lg bg-gray-50 p-3">
-                <div className="size-6 bg-gray-200 rounded"></div>
+              <div
+                key={i}
+                className="flex items-center gap-3 rounded-lg bg-gray-50 p-3"
+              >
+                <div className="size-6 rounded bg-gray-700"></div>
                 <div className="flex-1">
-                  <div className="h-4 w-32 bg-gray-200 rounded mb-1"></div>
-                  <div className="h-3 w-20 bg-gray-200 rounded"></div>
+                  <div className="mb-1 h-4 w-32 rounded bg-gray-700"></div>
+                  <div className="h-3 w-20 rounded bg-gray-700"></div>
                 </div>
-                <div className="h-5 w-16 bg-gray-200 rounded"></div>
+                <div className="h-5 w-16 rounded bg-gray-700"></div>
               </div>
             ))}
           </div>

--- a/my-app/src/components/skeletons/TransactionsSkeleton.tsx
+++ b/my-app/src/components/skeletons/TransactionsSkeleton.tsx
@@ -2,33 +2,33 @@ export const TransactionsSkeleton = () => {
   return (
     <div className="content-wrapper animate-pulse">
       {/* Year/Month Filter Skeleton */}
-      <div className="flex self-center rounded-lg border border-gray-200 bg-gray-100 p-2 shadow-sm h-10 w-64"></div>
+      <div className="flex h-10 w-64 self-center rounded-lg border border-gray-700 bg-gray-800 p-2 shadow-sm"></div>
 
       {/* Sort and Search Controls Skeleton */}
       <div className="ml-auto flex items-center gap-3">
-        <div className="h-9 w-24 bg-gray-100 rounded-lg border border-gray-300"></div>
-        <div className="h-9 w-40 bg-gray-100 rounded-lg border border-gray-300"></div>
+        <div className="h-9 w-24 rounded-lg border border-gray-700 bg-gray-800"></div>
+        <div className="h-9 w-40 rounded-lg border border-gray-700 bg-gray-800"></div>
       </div>
 
       {/* Spending List Skeleton */}
-      <div className="bg-background w-full rounded-2xl border border-solid border-gray-200 p-5 shadow-sm">
+      <div className="bg-background w-full rounded-2xl border border-solid border-gray-700 p-5 shadow-sm">
         {/* Spending Items Skeleton */}
         <div className="flex flex-col gap-3">
           {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
             <div key={i}>
-              <div className="mb-2 h-5 w-24 bg-gray-200 rounded"></div>
+              <div className="mb-2 h-5 w-24 rounded bg-gray-700"></div>
               <div className="flex flex-col gap-2">
                 {[1, 2, 3].map((j) => (
                   <div
                     key={j}
                     className="flex items-center gap-2 rounded-lg bg-gray-50 p-3"
                   >
-                    <div className="size-6 bg-gray-200 rounded"></div>
+                    <div className="size-6 rounded bg-gray-700"></div>
                     <div className="flex-1">
-                      <div className="h-4 w-32 bg-gray-200 rounded mb-1"></div>
-                      <div className="h-3 w-20 bg-gray-200 rounded"></div>
+                      <div className="mb-1 h-4 w-32 rounded bg-gray-700"></div>
+                      <div className="h-3 w-20 rounded bg-gray-700"></div>
                     </div>
-                    <div className="h-5 w-16 bg-gray-200 rounded"></div>
+                    <div className="h-5 w-16 rounded bg-gray-700"></div>
                   </div>
                 ))}
               </div>

--- a/my-app/src/components/skeletons/TransactionsSkeleton.tsx
+++ b/my-app/src/components/skeletons/TransactionsSkeleton.tsx
@@ -21,7 +21,7 @@ export const TransactionsSkeleton = () => {
                 {[1, 2, 3].map((j) => (
                   <div
                     key={j}
-                    className="flex items-center gap-2 rounded-lg bg-gray-50 p-3"
+                    className="flex items-center gap-2 rounded-lg bg-gray-800 p-3"
                   >
                     <div className="size-6 rounded bg-gray-700"></div>
                     <div className="flex-1">

--- a/my-app/src/composites/Account.tsx
+++ b/my-app/src/composites/Account.tsx
@@ -45,7 +45,7 @@ export const Account = (props: Props) => {
           onClick={() => {
             close();
           }}
-          className="text-primary-300 hover:bg-primary-100 hover:text-text flex shrink-0 items-center justify-center rounded-md p-2 transition-all"
+          className="text-primary-500 hover:bg-primary-100 hover:text-text flex shrink-0 items-center justify-center rounded-md p-2 transition-all"
         >
           <span className="text-xs">登入</span>
         </Link>

--- a/my-app/src/composites/AsideMenu.tsx
+++ b/my-app/src/composites/AsideMenu.tsx
@@ -66,14 +66,14 @@ export const AsideMenu = (props: Props) => {
       ></div>
       <aside
         ref={asideRef}
-        className="fixed top-0 bottom-0 -left-72 z-50 flex w-72 origin-right flex-col items-center justify-between border-r border-gray-700 bg-gray-800 shadow-2xl transition-all max-md:hidden"
+        className="fixed top-0 bottom-0 -left-72 z-50 flex w-72 origin-right flex-col items-center justify-between border-r border-gray-700 bg-gray-950 shadow-lg transition-all max-md:hidden"
       >
         <div className="gradient-glow clip-profile-bg absolute h-30 w-full"></div>
         <div className="relative flex w-full flex-col items-center pt-17">
           <Link
             href="/profile"
             onClick={onClose}
-            className="hover:ring-primary-500 active:ring-primary-600 flex size-20 items-center justify-center rounded-full bg-gray-700 p-1 shadow-xl ring-4 ring-gray-600 transition-all hover:shadow-[0_0_20px_rgba(6,182,212,0.4)]"
+            className="hover:ring-primary-500 active:ring-primary-600 flex size-20 items-center justify-center rounded-full bg-gray-950 p-1 ring-4 ring-gray-950 transition-all"
           >
             <UserAvatar user={user} />
           </Link>
@@ -90,7 +90,7 @@ export const AsideMenu = (props: Props) => {
           </p>
         </div>
         <div className="flex h-px w-full items-center px-4 py-5">
-          <span className="h-px w-full bg-linear-to-r from-transparent via-gray-600 to-transparent"></span>
+          <span className="h-px w-full bg-gray-700"></span>
         </div>
         <div className="flex w-full flex-1 flex-col items-center gap-1 px-4">
           {Object.keys(MENU_CONFIG).map((path) => (
@@ -148,7 +148,7 @@ const MenuButton = ({
       <Link
         href={href}
         onClick={onClick}
-        className={`flex min-h-11 w-full cursor-pointer items-center rounded-xl px-5 py-3 text-left text-sm font-semibold transition-all duration-200 sm:text-base ${pathName === href ? 'bg-primary-900/30 text-primary-400 shadow-primary-glow' : 'hover:text-primary-400 text-gray-300 hover:bg-gray-700 active:bg-gray-600'}`}
+        className={`flex min-h-11 w-full cursor-pointer items-center rounded-xl px-5 py-3 text-left text-sm font-semibold transition-all duration-200 sm:text-base ${pathName === href ? 'bg-primary-50 text-primary-500' : 'hover:text-primary-500 text-gray-300 hover:bg-gray-800 active:bg-gray-700/60'}`}
       >
         {icon ?? ROUTE_ICON[href]}
         {label}
@@ -158,7 +158,7 @@ const MenuButton = ({
   return (
     <button
       onClick={onClick}
-      className="hover:text-primary-400 flex min-h-11 w-full cursor-pointer items-center rounded-xl px-5 py-3 text-left text-sm font-semibold text-gray-300 transition-all duration-200 hover:bg-gray-700 active:bg-gray-600 sm:text-base"
+      className="hover:text-primary-500 flex min-h-11 w-full cursor-pointer items-center rounded-xl px-5 py-3 text-left text-sm font-semibold text-gray-300 transition-all duration-200 hover:bg-gray-800 active:bg-gray-700/60 sm:text-base"
     >
       {icon}
       {label}

--- a/my-app/src/composites/BottomNav.tsx
+++ b/my-app/src/composites/BottomNav.tsx
@@ -26,17 +26,17 @@ export const BottomNav = () => {
 
   return (
     <nav
-      className="fixed right-0 bottom-0 left-0 z-40 border-t border-white/[0.06] md:hidden"
-      style={{ backgroundColor: 'rgba(10, 14, 26, 0.7)', backdropFilter: 'blur(20px)', WebkitBackdropFilter: 'blur(20px)' }}
+      className="fixed right-0 bottom-0 left-0 z-40 border-t border-black/[0.08] md:hidden"
+      style={{
+        backgroundColor: 'rgba(245, 245, 247, 0.8)',
+        backdropFilter: 'saturate(180%) blur(20px)',
+        WebkitBackdropFilter: 'saturate(180%) blur(20px)',
+      }}
       aria-label="Mobile navigation"
     >
       <div className="safe-area-inset-bottom relative mx-auto grid max-w-md grid-cols-5 items-center px-2 pt-1.5 pb-2">
         {LEFT_ROUTES.map((route) => (
-          <NavItem
-            key={route}
-            route={route}
-            isActive={pathname === route}
-          />
+          <NavItem key={route} route={route} isActive={pathname === route} />
         ))}
 
         {/* Centered FAB */}
@@ -45,8 +45,8 @@ export const BottomNav = () => {
             href="/edit"
             className="flex size-14 -translate-y-3 items-center justify-center rounded-full text-white transition-transform duration-150 active:scale-95"
             style={{
-              background: 'linear-gradient(135deg, #06B6D4, #0891B2)',
-              boxShadow: '0 8px 24px rgba(6, 182, 212, 0.4)',
+              background: 'var(--color-primary-500)',
+              boxShadow: '0 8px 24px rgba(0, 0, 0, 0.16)',
             }}
             aria-label="新增帳目"
             scroll={false}
@@ -56,11 +56,7 @@ export const BottomNav = () => {
         </div>
 
         {RIGHT_ROUTES.map((route) => (
-          <NavItem
-            key={route}
-            route={route}
-            isActive={pathname === route}
-          />
+          <NavItem key={route} route={route} isActive={pathname === route} />
         ))}
       </div>
     </nav>
@@ -71,7 +67,7 @@ const NavItem = ({ route, isActive }: { route: string; isActive: boolean }) => (
   <Link
     href={route}
     className={`relative flex min-h-11 flex-col items-center justify-center gap-0.5 rounded-xl py-1 transition-colors ${
-      isActive ? 'text-primary-400' : 'text-gray-500 hover:text-gray-300'
+      isActive ? 'text-primary-500' : 'text-gray-500 hover:text-gray-300'
     }`}
     aria-label={MENU_CONFIG[route]}
     aria-current={isActive ? 'page' : undefined}

--- a/my-app/src/composites/Caption.tsx
+++ b/my-app/src/composites/Caption.tsx
@@ -39,7 +39,7 @@ export const Caption = ({ openAside }: { openAside: () => void }) => {
 
   return (
     <div
-      className="sticky top-0 left-0 z-40 w-full border-b border-white/[0.06]"
+      className="sticky top-0 left-0 z-40 w-full border-b border-black/[0.08]"
       style={{ backgroundColor: 'var(--color-bg-primary)' }}
     >
       <div className="relative mx-auto flex max-w-7xl flex-col gap-2 px-4 py-3 md:flex-row md:items-center md:gap-3">
@@ -56,7 +56,7 @@ export const Caption = ({ openAside }: { openAside: () => void }) => {
             </div>
             <div className="flex flex-col leading-tight">
               <span
-                className="text-[15px] font-bold whitespace-nowrap text-gray-100 sm:text-base"
+                className="text-[15px] font-semibold whitespace-nowrap text-gray-100 sm:text-base"
                 style={{ fontFamily: 'var(--font-heading)' }}
               >
                 {greetingLabel}，
@@ -80,7 +80,7 @@ export const Caption = ({ openAside }: { openAside: () => void }) => {
           <Link
             href="/edit"
             scroll={false}
-            className="group btn-add-header hidden md:flex items-center gap-1.5 whitespace-nowrap rounded-[10px] px-3.5 py-2 text-sm font-semibold text-white"
+            className="group btn-add-header hidden items-center gap-1.5 px-3.5 py-2 text-sm whitespace-nowrap text-white md:flex"
             aria-label="新增帳目"
           >
             <IoMdAdd className="size-[15px] shrink-0 transition-transform duration-200 group-hover:rotate-90" />

--- a/my-app/src/composites/EditExpenseModal.tsx
+++ b/my-app/src/composites/EditExpenseModal.tsx
@@ -19,13 +19,7 @@ import {
   SpendingType,
 } from '@/utils/constants';
 import { getSpendingCategoryMap } from '@/utils/getSpendingCategoryMap';
-import {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { IoArrowBack, IoCheckmarkSharp } from 'react-icons/io5';
 import { v7 as uuid } from 'uuid';
 
@@ -215,11 +209,11 @@ export const EditExpenseModal = (props: Props) => {
 
   return (
     <ModalShell onClose={onClose}>
-      <header className="relative flex items-center justify-between gap-3 border-b border-white/[0.06] px-4 py-3">
+      <header className="relative flex items-center justify-between gap-3 border-b border-black/[0.08] px-4 py-3">
         <button
           type="button"
           onClick={handleHeaderLeft}
-          className="flex size-9 items-center justify-center rounded-full text-gray-300 transition-colors hover:bg-white/[0.06] hover:text-gray-100"
+          className="flex size-9 items-center justify-center rounded-full text-gray-300 transition-colors hover:bg-black/[0.05] hover:text-gray-100"
           aria-label={step === 2 ? '返回上一步' : '關閉'}
         >
           {step === 2 ? (
@@ -304,7 +298,7 @@ const ModalShell = ({
     <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 backdrop-blur-sm sm:items-center sm:p-4">
       <div
         ref={contentRef}
-        className="animate-modal flex max-h-[95dvh] w-full flex-col overflow-hidden rounded-t-[24px] border border-white/[0.06] bg-gray-800 shadow-2xl sm:max-w-md sm:rounded-2xl"
+        className="animate-modal flex max-h-[95dvh] w-full flex-col overflow-hidden rounded-t-[24px] border border-black/[0.08] bg-gray-950 shadow-xl sm:max-w-md sm:rounded-2xl"
         style={{ backgroundColor: 'var(--color-bg-secondary)' }}
       >
         {children}
@@ -323,7 +317,7 @@ const StepDots = ({ step }: { step: Step }) => (
       style={{
         width: step === 1 ? 16 : 6,
         backgroundColor:
-          step === 1 ? 'var(--color-primary-400)' : 'rgba(255,255,255,0.2)',
+          step === 1 ? 'var(--color-primary-500)' : 'rgba(0,0,0,0.15)',
       }}
     />
     <span
@@ -332,7 +326,7 @@ const StepDots = ({ step }: { step: Step }) => (
       style={{
         width: step === 2 ? 16 : 6,
         backgroundColor:
-          step === 2 ? 'var(--color-primary-400)' : 'rgba(255,255,255,0.2)',
+          step === 2 ? 'var(--color-primary-500)' : 'rgba(0,0,0,0.15)',
       }}
     />
   </div>
@@ -401,7 +395,7 @@ const StepAmount = ({
               key={q}
               type="button"
               onClick={() => onAddQuick(q)}
-              className="rounded-full border border-white/[0.08] bg-white/[0.03] px-3.5 py-1 text-xs font-semibold text-gray-300 transition-colors hover:bg-white/[0.06]"
+              className="rounded-full border border-black/[0.10] bg-black/[0.03] px-3.5 py-1 text-xs font-semibold text-gray-300 transition-colors hover:bg-black/[0.05]"
               style={{ fontVariantNumeric: 'tabular-nums' }}
             >
               +{formatAmount(String(q))}
@@ -410,14 +404,11 @@ const StepAmount = ({
         </div>
 
         {/* Calculator */}
-        <NumberKeyboard
-          value={amountStr}
-          onChange={onChangeAmount}
-        />
+        <NumberKeyboard value={amountStr} onChange={onChangeAmount} />
       </div>
 
       {/* Footer CTA */}
-      <div className="border-t border-white/[0.06] px-5 py-3">
+      <div className="border-t border-black/[0.08] px-5 py-3">
         <button
           type="button"
           onClick={onNext}
@@ -479,7 +470,7 @@ const StepDetails = ({
       <div className="flex flex-1 flex-col gap-5 overflow-y-auto px-5 pt-4 pb-2">
         {/* Amount summary */}
         <div
-          className="flex items-baseline justify-between rounded-xl border border-white/[0.06] bg-white/[0.02] px-3.5 py-2.5"
+          className="flex items-baseline justify-between rounded-xl border border-black/[0.08] bg-black/[0.02] px-3.5 py-2.5"
           style={{ fontVariantNumeric: 'tabular-nums' }}
         >
           <span className="text-sm text-gray-400">金額</span>
@@ -501,7 +492,7 @@ const StepDetails = ({
             option1={{ label: '支出', value: SpendingType.Outcome }}
             option2={{ label: '收入', value: SpendingType.Income }}
             value={spendingType}
-            className="h-10 w-full border border-solid border-white/[0.06] text-sm"
+            className="h-10 w-full border border-solid border-black/[0.08] text-sm"
             onChange={onSetSpendingType}
           />
         </Section>
@@ -518,7 +509,7 @@ const StepDetails = ({
               value: Necessity.NotNeed,
             }}
             value={necessity}
-            className="h-10 w-full border border-solid border-white/[0.06] text-sm"
+            className="h-10 w-full border border-solid border-black/[0.08] text-sm"
             onChange={onSetNecessity}
           />
         </Section>
@@ -536,11 +527,11 @@ const StepDetails = ({
                   className="flex flex-col items-center justify-center gap-0.5 rounded-xl border px-1 py-2 transition-colors"
                   style={{
                     borderColor: selected
-                      ? 'rgba(6, 182, 212, 0.5)'
-                      : 'rgba(255,255,255,0.06)',
+                      ? 'rgba(0, 102, 204, 0.5)'
+                      : 'rgba(0,0,0,0.08)',
                     background: selected
-                      ? 'linear-gradient(180deg, rgba(6,182,212,0.18), rgba(6,182,212,0.04))'
-                      : 'rgba(255,255,255,0.02)',
+                      ? 'rgba(0, 102, 204, 0.08)'
+                      : 'rgba(0,0,0,0.02)',
                   }}
                   title={CATEGORY_WORDING_MAP[cat.value] || cat.label}
                 >
@@ -551,7 +542,7 @@ const StepDetails = ({
                     className="text-[10.5px] font-semibold"
                     style={{
                       color: selected
-                        ? 'var(--color-primary-400)'
+                        ? 'var(--color-primary-500)'
                         : 'var(--color-text-tertiary)',
                     }}
                   >
@@ -569,7 +560,7 @@ const StepDetails = ({
             type="text"
             id="description"
             name="description"
-            className="hover:border-primary-600 h-10 w-full rounded-xl border border-solid border-white/[0.06] bg-white/[0.02] px-3 py-1 text-gray-100 placeholder:text-gray-500 transition-colors focus:outline-0"
+            className="hover:border-primary-600 h-10 w-full rounded-xl border border-solid border-black/[0.08] bg-black/[0.02] px-3 py-1 text-gray-100 transition-colors placeholder:text-gray-500 focus:outline-0"
             autoComplete="off"
             placeholder="例如：午餐、咖啡、薪水"
             onChange={(e) => onSetDescription(e.target.value)}
@@ -593,15 +584,15 @@ const StepDetails = ({
                   style={{
                     borderColor:
                       description === commonDesc
-                        ? 'rgba(6, 182, 212, 0.5)'
-                        : 'rgba(255,255,255,0.08)',
+                        ? 'rgba(0, 102, 204, 0.5)'
+                        : 'rgba(0,0,0,0.10)',
                     background:
                       description === commonDesc
-                        ? 'rgba(6, 182, 212, 0.10)'
+                        ? 'rgba(0, 102, 204, 0.08)'
                         : 'transparent',
                     color:
                       description === commonDesc
-                        ? 'var(--color-primary-300)'
+                        ? 'var(--color-primary-500)'
                         : 'var(--color-text-tertiary)',
                   }}
                 >
@@ -617,7 +608,7 @@ const StepDetails = ({
               disabled={updatingCategory}
               className={`w-full rounded-lg border border-solid p-2 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
                 isNewDesc
-                  ? 'border-primary-700 bg-primary-900/20 text-primary-400'
+                  ? 'border-primary-500 bg-primary-50 text-primary-500'
                   : 'border-[var(--color-expense)]/40 text-[var(--color-expense)]'
               }`}
               onClick={() => onToggleCommonDesc(isNewDesc)}
@@ -634,7 +625,7 @@ const StepDetails = ({
         {/* Date */}
         <Section label="日期">
           <DatePicker
-            className="hover:border-primary-600 h-10 w-full rounded-xl border border-solid border-white/[0.06] bg-white/[0.02] transition-colors"
+            className="hover:border-primary-600 h-10 w-full rounded-xl border border-solid border-black/[0.08] bg-black/[0.02] transition-colors"
             labelClassName="text-sm px-3 py-1"
             format="yyyy/mm/dd"
             init={dateInit}
@@ -643,9 +634,12 @@ const StepDetails = ({
       </div>
 
       {/* Footer submit */}
-      <div className="border-t border-white/[0.06] px-5 py-3">
+      <div className="border-t border-black/[0.08] px-5 py-3">
         {loading ? (
-          <div className="flex items-center justify-center" style={{ minHeight: 48 }}>
+          <div
+            className="flex items-center justify-center"
+            style={{ minHeight: 48 }}
+          >
             <Loading className="size-6 animate-spin text-white" />
           </div>
         ) : (
@@ -675,7 +669,7 @@ const Section = ({
 }) => (
   <div className="flex flex-col gap-2">
     <span
-      className="text-[11px] font-semibold uppercase text-gray-400"
+      className="text-[11px] font-semibold text-gray-400 uppercase"
       style={{ letterSpacing: '0.12em' }}
     >
       {label}

--- a/my-app/src/composites/GroupSelector.tsx
+++ b/my-app/src/composites/GroupSelector.tsx
@@ -26,7 +26,7 @@ export const GroupSelector = ({ className = '' }: { className?: string }) => {
       name="group"
       value={currentGroup?.name ?? '載入帳本資訊中...'}
       onChange={handleOnSelectGroup}
-      className={`hover:border-primary-400 active:border-primary-500 max-w-50 rounded-xl border-2 border-solid border-gray-600 bg-gray-800/90 px-4 py-2 text-gray-100 backdrop-blur-sm transition-all duration-200 hover:shadow-[0_0_20px_rgba(6,182,212,0.3)] ${className}`}
+      className={`hover:border-primary-400 active:border-primary-500 max-w-50 rounded-full border border-solid border-gray-700 bg-gray-950/90 px-4 py-2 text-gray-100 backdrop-blur-sm transition-all duration-200 ${className}`}
     >
       {!loading &&
         groups.map(

--- a/my-app/src/styles/colors.ts
+++ b/my-app/src/styles/colors.ts
@@ -94,6 +94,11 @@ export const ACCENT_COLORS = {
 
 /**
  * 灰階顏色（Apple 中性灰 — 近黑 ink 到純白 canvas）
+ *
+ * 注意：此常數依「數字小 = 淺、數字大 = 深」的自然順序排列，
+ * 與 globals.css 中語意反轉後的 Tailwind `gray-*` class **不對應**
+ * （例如 `bg-gray-50` 會渲染成 ink 深色，而 GRAY_COLORS[50] 是白色）。
+ * 在 TSX 中請使用 Tailwind class；此常數僅供 runtime（圖表等）取色。
  */
 export const GRAY_COLORS = {
   50: '#FFFFFF',

--- a/my-app/src/styles/colors.ts
+++ b/my-app/src/styles/colors.ts
@@ -1,11 +1,11 @@
 /**
- * Color System - Solo Leveling Dark Theme
+ * Color System - Apple-style Light Theme（依 DESIGN.md）
  *
  * 統一的顏色管理系統
  * 所有顏色都應該使用這裡定義的常數，而不是硬編碼
  *
  * 這些顏色對應 globals.css 中的 CSS 變數
- * 配色靈感：獨自升級（Solo Leveling）- 冷色系深色主題
+ * 設計原則：白/羊皮紙淺色畫布、近黑 ink 文字、單一 Action Blue (#0066CC) 互動色
  */
 
 // ============================================================================
@@ -14,36 +14,36 @@
 
 /**
  * 圖表顏色配置
- * 對應冷色系配色方案（青藍色、紫色、藍色為主）
+ * 淺色底圖表用中等飽和度色彩，維持紅支出 / 綠收入的金融慣例
  */
 export const CHART_COLORS = {
-  // 收入圖表（翡翠綠系）
-  INCOME_PRIMARY: '#10B981',      // --color-income-500
-  INCOME_NECESSARY: '#34D399',    // --color-income-400 必要收入（較亮）
-  INCOME_UNNECESSARY: '#6EE7B7',  // --color-income-300 非必要收入（更亮）
+  // 收入圖表（綠系）
+  INCOME_PRIMARY: '#248A3D', // --color-income-500
+  INCOME_NECESSARY: '#2DA44E', // --color-income-400 必要收入（較亮）
+  INCOME_UNNECESSARY: '#7DD89E', // --color-income-300 非必要收入（更亮）
 
-  // 支出圖表（珊瑚紅系 - 符合金融慣例）
-  OUTCOME_PRIMARY: '#F87171',     // coral-400 取代紫色
-  OUTCOME_NECESSARY: '#FCA5A5',   // coral-300 必要支出（較亮）
-  OUTCOME_UNNECESSARY: '#FECACA', // coral-200 非必要支出（更亮）
+  // 支出圖表（紅系 - 符合金融慣例）
+  OUTCOME_PRIMARY: '#E30000', // 支出主色
+  OUTCOME_NECESSARY: '#FF6961', // 必要支出（較亮）
+  OUTCOME_UNNECESSARY: '#FFB3AE', // 非必要支出（更亮）
 
   // 通用
-  NEUTRAL: '#475569',             // --color-gray-600
+  NEUTRAL: '#86868B', // --color-gray-500
 } as const;
 
 /**
  * 圖表顏色陣列（用於多系列圖表）
- * 按照推薦順序排列 - 冷色系 Solo Leveling 風格
+ * 以 Action Blue 為首的低調系統色盤，適合白底
  */
 export const CHART_COLOR_PALETTE = [
-  '#06B6D4',   // Primary cyan (主青色)
-  '#A855F7',   // Secondary purple (紫色)
-  '#3B82F6',   // Accent blue (藍色)
-  '#22D3EE',   // Light cyan (淺青)
-  '#C084FC',   // Light purple (淺紫)
-  '#10B981',   // Emerald (翡翠綠)
-  '#60A5FA',   // Light blue (淺藍)
-  '#F472B6',   // Pink (粉紅)
+  '#0066CC', // Action Blue（主互動色）
+  '#248A3D', // Green（收入綠）
+  '#B25000', // Orange（暖色對比）
+  '#0071E3', // Focus Blue
+  '#6BA6E0', // Light blue
+  '#2DA44E', // Light green
+  '#86868B', // Neutral gray
+  '#E30000', // Red（支出紅）
 ] as const;
 
 // ============================================================================
@@ -51,62 +51,62 @@ export const CHART_COLOR_PALETTE = [
 // ============================================================================
 
 /**
- * 主要品牌色（青藍色）
+ * 主要品牌色（Action Blue — 全站唯一互動色）
  */
 export const PRIMARY_COLORS = {
-  50: '#ECFEFF',
-  100: '#CFFAFE',
-  200: '#A5F3FC',
-  300: '#67E8F9',
-  400: '#22D3EE',
-  500: '#06B6D4',  // 主青色
-  600: '#0891B2',
-  700: '#0E7490',
-  800: '#155E75',
-  900: '#164E63',
+  50: '#F2F7FC',
+  100: '#D9E8F7',
+  200: '#B3D1EF',
+  300: '#6BA6E0',
+  400: '#0071E3', // Focus Blue
+  500: '#0066CC', // Action Blue
+  600: '#0055AB',
+  700: '#00468C',
+  800: '#00386F',
+  900: '#002B55',
 } as const;
 
 /**
- * 輔助色 - Accent Colors（冷色系）
+ * 輔助色 - Accent Colors（無第二品牌色，僅保留功能性色彩）
  */
 export const ACCENT_COLORS = {
-  // 紫色（神秘魔力感）
+  // 藍色（= Action Blue，向後相容別名）
   purple: {
-    100: '#F3E8FF',
-    500: '#A855F7',
+    100: '#D9E8F7',
+    500: '#0066CC',
   },
-  // 電光藍
+  // 藍色
   blue: {
-    100: '#DBEAFE',
-    500: '#3B82F6',
+    100: '#D9E8F7',
+    500: '#0066CC',
   },
-  // 翡翠綠（收入）
+  // 綠色（收入）
   green: {
-    100: '#D1FAE5',
-    500: '#10B981',
+    100: '#D8F3E0',
+    500: '#248A3D',
   },
-  // 粉紅色（圖表用）
+  // 紅色（圖表用，支出語意）
   pink: {
-    100: '#FCE7F3',
-    500: '#EC4899',
+    100: '#FFD9D6',
+    500: '#E30000',
   },
 } as const;
 
 /**
- * 灰階顏色（Slate 冷灰調）
+ * 灰階顏色（Apple 中性灰 — 近黑 ink 到純白 canvas）
  */
 export const GRAY_COLORS = {
-  50: '#F8FAFC',
-  100: '#F1F5F9',
-  200: '#E2E8F0',
-  300: '#CBD5E1',
-  400: '#94A3B8',
-  500: '#64748B',
-  600: '#475569',
-  700: '#334155',
-  800: '#1E293B',
-  900: '#0F172A',
-  950: '#020617',
+  50: '#FFFFFF',
+  100: '#FAFAFC',
+  200: '#F5F5F7',
+  300: '#E8E8ED',
+  400: '#D2D2D7',
+  500: '#A1A1A6',
+  600: '#86868B',
+  700: '#7A7A7A',
+  800: '#494949',
+  900: '#333333',
+  950: '#1D1D1F',
 } as const;
 
 /**
@@ -120,39 +120,39 @@ export const GRAY_COLORS = {
  * - `primaryGlow` 是 RGB 字串，用於 `rgba(var(--...), .X)` 樣式
  */
 export const MONEY_COLORS = {
-  income: '#34D399', // emerald-400
-  incomeMuted: 'rgba(52, 211, 153, 0.10)',
-  expense: '#F87171', // coral-400 取代紫色
-  expenseMuted: 'rgba(248, 113, 113, 0.10)',
-  overBudget: '#FB7185', // rose-400 比 expense 更鮮
-  warning: '#FBBF24', // amber-400
+  income: '#248A3D', // green — 白底可讀
+  incomeMuted: 'rgba(36, 138, 61, 0.10)',
+  expense: '#E30000', // red
+  expenseMuted: 'rgba(227, 0, 0, 0.08)',
+  overBudget: '#D70015', // 比 expense 更深的警示紅
+  warning: '#B25000', // 白底可讀的橘
   primary: PRIMARY_COLORS[500],
-  primaryGlow: '6, 182, 212', // rgb 字串給 rgba() 用
+  primaryGlow: '0, 102, 204', // rgb 字串給 rgba() 用
 } as const;
 
 /**
  * 語義化顏色
  */
 export const SEMANTIC_COLORS = {
-  // 成功（翡翠綠）
+  // 成功（綠）
   success: ACCENT_COLORS.green[500],
   successLight: ACCENT_COLORS.green[100],
 
-  // 警告（金黃色）
-  warning: '#FBBF24',
-  warningLight: '#FEF3C7',
+  // 警告（橘）
+  warning: '#B25000',
+  warningLight: '#FFF3E0',
 
-  // 錯誤（珊瑚紅）
-  error: '#F87171',
-  errorLight: '#FEE2E2',
+  // 錯誤（紅）
+  error: '#E30000',
+  errorLight: '#FFD9D6',
 
-  // 資訊（青藍色）
+  // 資訊（Action Blue）
   info: PRIMARY_COLORS[500],
   infoLight: PRIMARY_COLORS[100],
 
   // 中性
   neutral: GRAY_COLORS[600],
-  neutralLight: GRAY_COLORS[700],
+  neutralLight: GRAY_COLORS[400],
 } as const;
 
 // ============================================================================
@@ -188,19 +188,19 @@ export const getChartColor = (index: number): string => {
 /**
  * @deprecated 使用 CHART_COLORS.INCOME_PRIMARY
  */
-export const LEGACY_INCOME_COLOR = '#10B981';
+export const LEGACY_INCOME_COLOR = '#248A3D';
 
 /**
  * @deprecated 使用 CHART_COLORS.OUTCOME_PRIMARY 或 MONEY_COLORS.expense
  */
-export const LEGACY_OUTCOME_COLOR = '#F87171';
+export const LEGACY_OUTCOME_COLOR = '#E30000';
 
 /**
  * @deprecated 使用 CHART_COLORS.NEUTRAL
  */
-export const LEGACY_NEUTRAL_COLOR = '#475569';
+export const LEGACY_NEUTRAL_COLOR = '#86868B';
 
 /**
  * @deprecated 使用 CHART_COLORS.INCOME_NECESSARY / OUTCOME_NECESSARY
  */
-export const LEGACY_NECESSARY_COLOR = '#22D3EE';
+export const LEGACY_NECESSARY_COLOR = '#0071E3';


### PR DESCRIPTION
[Why] The app shipped with a dark cyan/purple theme that diverged from the design source of truth. DESIGN.md defines an Apple-style light design language (white/parchment canvas, near-black ink text, a single Action Blue accent, pill CTAs, hairline borders, no decorative gradients or glow shadows), and the UI should follow it consistently across all pages.

[How]
- Rewrite `globals.css` design tokens: light canvas (`#ffffff` / `#f5f5f7` parchment), ink text (`#1d1d1f`), single Action Blue (`#0066cc`) accent ramp, SF Pro system font stack, hairline border tokens, and DESIGN.md radius/spacing scales
- Invert the gray token scale so existing dark-theme utility classes (`text-gray-100`, `bg-gray-800`, ...) resolve to the equivalent light-theme semantics without touching every call site
- Alias `secondary-*` / `accent-*` color tokens to the Action Blue ramp (single-accent principle)
- Restyle button classes (`.btn-primary`, `.btn-secondary`, `.submit-button`, `.btn-add-header`) as flat Action Blue / ghost pills with `scale(0.95)` press state; cards become white surfaces with hairline borders and no shadow
- Remove all cyan glow `box-shadow`s, gradient fills, and gradient text across ~30 components; convert translucent-white hairlines/fills to translucent-black equivalents
- Rebuild `colors.ts` chart palette and UI constants for white surfaces, keeping red-expense / green-income money semantics with light-readable shades; over-budget warnings now use the expense red instead of the old purple
- Remap skeletons and tables that were written with light-gray conventions to the inverted token scale; keep the full-screen image cropper dark (photo-editing context)
- Drop the Google Fonts links from `layout.tsx` in favor of the system font stack

[Affected Pages]
- / (dashboard)
- /transactions
- /analysis
- /budget
- /group, /group/invite/[id]
- /setting
- /profile
- /login
- /edit (modal)

---

[中文摘要]
- 依 DESIGN.md 將全站從深色青紫主題改版為 Apple 風格的淺色設計：白底／米白畫布、近黑文字、單一藍色為所有互動色。
- 按鈕統一為藍色膠囊樣式並加上按壓縮放回饋；卡片改為白底細邊框、不帶陰影；移除所有發光與漸層裝飾。
- 字體改用系統字體（SF Pro），不再載入外部 Google Fonts，並依設計規範調整標題與內文的字級與字距。
- 圖表與預算配色同步調整為適合淺色背景的紅（支出）／綠（收入）語意色，超支警示改為紅色。
- 載入中的骨架畫面、表格與各頁細節一併校正，確保深淺色轉換後文字與邊框對比正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)