### PR TITLE
Fix stale data on route changes by switching SW API cache to network-first

### DIFF
--- a/my-app/public/sw.js
+++ b/my-app/public/sw.js
@@ -1,7 +1,15 @@
-// Service Worker — stale-while-revalidate for read-only Aurora API endpoints.
-// Mutations (POST/PUT/DELETE) and auth/sync routes are bypassed.
+// Service Worker — network-first (cache as offline fallback) for read-only
+// Aurora API endpoints. Mutations (POST/PUT/DELETE) and auth/sync routes are
+// bypassed.
+//
+// Why network-first instead of stale-while-revalidate: SWR returned the
+// PREVIOUS cached payload to the page on every navigation and only updated
+// the cache in the background, so the UI was always one navigation behind
+// (and stale responses overwrote optimistic updates in SpendingProvider).
+// Instant first paint is already handled by the persistent context providers
+// and the localStorage warm-start — the SW cache only needs to cover offline.
 
-const CACHE_NAME = 'aurora-api-v1';
+const CACHE_NAME = 'aurora-api-v2';
 const SWR_PATH_PREFIX = '/api/aurora/';
 const BYPASS_PATHS = [
   '/api/aurora/sync', // explicit pull-then-push, must hit network
@@ -32,31 +40,25 @@ self.addEventListener('fetch', (event) => {
   if (!url.pathname.startsWith(SWR_PATH_PREFIX)) return;
   if (BYPASS_PATHS.some((p) => url.pathname.startsWith(p))) return;
 
-  event.respondWith(staleWhileRevalidate(req));
+  event.respondWith(networkFirst(req));
 });
 
-async function staleWhileRevalidate(request) {
+async function networkFirst(request) {
   const cache = await caches.open(CACHE_NAME);
-  const cached = await cache.match(request);
 
-  const networkPromise = fetch(request)
-    .then((response) => {
-      if (response && response.status === 200) {
-        cache.put(request, response.clone()).catch(() => {});
-      }
-      return response;
-    })
-    .catch(() => null);
-
-  if (cached) {
-    // Fire-and-forget background revalidation; return cached now.
-    networkPromise.catch(() => {});
-    return cached;
+  try {
+    const response = await fetch(request);
+    if (response && response.status === 200) {
+      cache.put(request, response.clone()).catch(() => {});
+    }
+    return response;
+  } catch {
+    // Network unavailable — fall back to the last cached payload (offline).
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    return new Response(JSON.stringify({ status: false, message: 'offline' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
-
-  const fresh = await networkPromise;
-  return fresh || new Response(JSON.stringify({ status: false, message: 'offline' }), {
-    status: 503,
-    headers: { 'Content-Type': 'application/json' },
-  });
 }

--- a/my-app/public/sw.js
+++ b/my-app/public/sw.js
@@ -10,7 +10,7 @@
 // and the localStorage warm-start — the SW cache only needs to cover offline.
 
 const CACHE_NAME = 'aurora-api-v2';
-const SWR_PATH_PREFIX = '/api/aurora/';
+const API_PATH_PREFIX = '/api/aurora/';
 const BYPASS_PATHS = [
   '/api/aurora/sync', // explicit pull-then-push, must hit network
 ];
@@ -24,7 +24,9 @@ self.addEventListener('activate', (event) => {
     (async () => {
       const keys = await caches.keys();
       await Promise.all(
-        keys.filter((k) => k !== CACHE_NAME).map((k) => caches.delete(k)),
+        keys
+          .filter((k) => k.startsWith('aurora-api-') && k !== CACHE_NAME)
+          .map((k) => caches.delete(k)),
       );
       await self.clients.claim();
     })(),
@@ -37,7 +39,7 @@ self.addEventListener('fetch', (event) => {
 
   const url = new URL(req.url);
   if (url.origin !== self.location.origin) return;
-  if (!url.pathname.startsWith(SWR_PATH_PREFIX)) return;
+  if (!url.pathname.startsWith(API_PATH_PREFIX)) return;
   if (BYPASS_PATHS.some((p) => url.pathname.startsWith(p))) return;
 
   event.respondWith(networkFirst(req));


### PR DESCRIPTION
[Why] After editing or adding a record, switching routes still showed outdated data — users had to navigate back and forth to see the latest records. The service worker served every `/api/aurora/` GET with stale-while-revalidate, so each navigation rendered the previous cached payload while the fresh response only updated the cache in the background (always one navigation behind), and the stale response also overwrote optimistic updates in the spending context.

[How]
- Replace the stale-while-revalidate strategy in the service worker with network-first: fetch from the network, refresh the cache on success, and fall back to the cached payload only when the network is unavailable (offline support preserved)
- Bump the API cache name from `aurora-api-v1` to `aurora-api-v2` so stale entries are purged on activation
- Instant first paint is unaffected: it is already covered by the persistent context providers and the localStorage warm-start, so the SW cache only needs to cover offline

[Affected Pages]
- / (dashboard)
- /transactions
- /analysis
- /budget
- /group
- (every page that fetches `/api/aurora/` data)

---

[中文摘要]
- 修正切換頁面時資料總是慢一步、需要來回切換才會看到最新帳目的問題。
- 離線快取改為僅在無網路時作為備援，連線正常時一律向伺服器取得最新資料，離線仍可顯示最後一次的資料。

🤖 Generated with [Claude Code](https://claude.com/claude-code)