### PR TITLE
Use category icons instead of raw emoji in add/edit expense modal

### DIFF
--- a/my-app/src/composites/EditExpenseModal.tsx
+++ b/my-app/src/composites/EditExpenseModal.tsx
@@ -545,7 +545,9 @@ const StepDetails = ({
                     }}
                     aria-hidden
                   >
-                    {getCategoryIcon(cat.value, 'size-5') ?? cat.value}
+                    {getCategoryIcon(cat.value, 'size-5') ?? (
+                      <span className="text-xl leading-none">{cat.value}</span>
+                    )}
                   </span>
                   <span
                     className="text-[10.5px] font-semibold"

--- a/my-app/src/composites/EditExpenseModal.tsx
+++ b/my-app/src/composites/EditExpenseModal.tsx
@@ -18,6 +18,7 @@ import {
   OUTCOME_TYPE_MAP,
   SpendingType,
 } from '@/utils/constants';
+import { getCategoryIcon } from '@/utils/getCategoryIcon';
 import { getSpendingCategoryMap } from '@/utils/getSpendingCategoryMap';
 import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { IoArrowBack, IoCheckmarkSharp } from 'react-icons/io5';
@@ -535,8 +536,16 @@ const StepDetails = ({
                   }}
                   title={CATEGORY_WORDING_MAP[cat.value] || cat.label}
                 >
-                  <span className="text-xl leading-none" aria-hidden>
-                    {cat.value}
+                  <span
+                    className="flex size-5 items-center justify-center"
+                    style={{
+                      color: selected
+                        ? 'var(--color-primary-500)'
+                        : 'var(--color-text-tertiary)',
+                    }}
+                    aria-hidden
+                  >
+                    {getCategoryIcon(cat.value, 'size-5') ?? cat.value}
                   </span>
                   <span
                     className="text-[10.5px] font-semibold"


### PR DESCRIPTION
[Why] The add/edit expense modal displayed raw emoji characters for categories, while the transactions list already renders them as Material Design icons — unify the visual language across the app.
[How]
- Replace the raw emoji character in the category grid of `EditExpenseModal` with the shared `getCategoryIcon` mapping (same source as the transactions list)
- Color the icon by selection state (primary when selected, tertiary otherwise), matching the existing category label colors
- Keep a fallback to the raw emoji for any category missing from the icon mapping
- Data layer unchanged — stored category values remain emoji

[Affected Pages]
- /transactions (add/edit expense modal)
- /edit (intercepted modal route)
- / (dashboard, where the edit modal can be opened)

---

[中文摘要]
- 統一類別的視覺呈現：新增／編輯帳目視窗中的類別選項，從直接顯示 emoji 改為與帳目列表相同的 icon 樣式。
- 僅調整顯示層，資料儲存格式不變，對既有帳目資料無影響。

🤖 Generated with [Claude Code](https://claude.com/claude-code)