### PR TITLE
fix(group): persist newly created/edited ledger to database

### DIFF
--- a/my-app/src/app/api/aurora/groups/route.ts
+++ b/my-app/src/app/api/aurora/groups/route.ts
@@ -13,7 +13,7 @@ export async function PUT(req: Request) {
     return Response.json(result);
   } catch (error) {
     console.error(error);
-    return Response.json({ message: 'Internal Server Error' });
+    return Response.json({ message: 'Internal Server Error' }, { status: 500 });
   }
 }
 
@@ -24,7 +24,7 @@ export async function POST(req: Request) {
     return Response.json(result);
   } catch (error) {
     console.error(error);
-    return Response.json({ message: 'Internal Server Error' });
+    return Response.json({ message: 'Internal Server Error' }, { status: 500 });
   }
 }
 
@@ -55,7 +55,7 @@ export async function GET(req: Request) {
     return Response.json(result);
   } catch (error) {
     console.error(error);
-    return Response.json({ message: 'Internal Server Error' });
+    return Response.json({ message: 'Internal Server Error' }, { status: 500 });
   }
 }
 
@@ -68,6 +68,6 @@ export async function DELETE(req: Request) {
     return Response.json(result);
   } catch (error) {
     console.error(error);
-    return Response.json({ message: 'Internal Server Error' });
+    return Response.json({ message: 'Internal Server Error' }, { status: 500 });
   }
 }

--- a/my-app/src/app/group/Dashboard.tsx
+++ b/my-app/src/app/group/Dashboard.tsx
@@ -6,12 +6,13 @@ import { EditIcon } from '@/components/icons/EditIcon';
 import { LeaveIcon } from '@/components/icons/LeaveIcon';
 import { LinkIcon } from '@/components/icons/LinkIcon';
 import { PlusIcon } from '@/components/icons/PlusIcon';
-import { RefreshIcon } from '@/components/icons/RefreshIcon';
 import { SendIcon } from '@/components/icons/SendIcon';
 import { Modal } from '@/components/Modal';
 import { useGroupCtx } from '@/context/GroupProvider';
 import { useUserConfigCtx } from '@/context/UserConfigProvider';
 import {
+  createGroup,
+  putGroup,
   removeGroupMember,
   getGroupMembers,
   deleteGroup,
@@ -20,15 +21,16 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import QRCode from 'react-qr-code';
 
 export const Dashboard = () => {
-  const { config: userData, syncUser } = useUserConfigCtx();
+  const { config: userData } = useUserConfigCtx();
   const {
     groups,
     syncGroup,
     setter: setGroups,
-    loading,
     currentGroup,
     setCurrentGroup,
   } = useGroupCtx();
+
+  const [isCreating, setIsCreating] = useState(false);
 
   const refresh = useCallback(() => {
     if (userData) {
@@ -37,19 +39,32 @@ export const Dashboard = () => {
   }, [userData, syncGroup]);
 
   const handleCreateGroup = useCallback(async () => {
-    if (!userData) return;
+    if (!userData || isCreating) return;
     const groupName = prompt('請輸入身分群組名稱');
-    if (!groupName) return;
-    const newGroup: Group = {
-      account_id: Date.now(),
-      name: groupName,
-      owner_id: userData.user_id,
-      members: [userData.user_id],
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    };
-    setGroups([...groups, newGroup], userData.user_id);
-  }, [userData, groups, setGroups]);
+    if (!groupName?.trim()) return;
+
+    setIsCreating(true);
+    try {
+      const newGroup: Group = {
+        account_id: Date.now(),
+        name: groupName.trim(),
+        owner_id: userData.user_id,
+        members: [userData.user_id],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+
+      const result = await createGroup(newGroup);
+      if (!result.status) {
+        alert(result.message || '建立失敗，請稍後再試');
+        return;
+      }
+      const serverGroup = result.data ?? newGroup;
+      setGroups([...groups, serverGroup], userData.user_id);
+    } finally {
+      setIsCreating(false);
+    }
+  }, [userData, isCreating, groups, setGroups]);
 
   return (
     <div className="content-wrapper">
@@ -57,10 +72,11 @@ export const Dashboard = () => {
         <button
           type="button"
           onClick={handleCreateGroup}
-          className="btn-primary flex min-h-11 items-center text-sm"
+          disabled={isCreating}
+          className="btn-primary flex min-h-11 items-center text-sm disabled:cursor-not-allowed disabled:opacity-50"
         >
           <PlusIcon className="mr-2 size-4" />
-          <span>建立新帳本</span>
+          <span>{isCreating ? '建立中...' : '建立新帳本'}</span>
         </button>
       </div>
       <div className="flex w-full flex-col gap-4 sm:flex-row sm:flex-wrap">
@@ -98,6 +114,7 @@ const GroupCard = ({
   const { config: userData } = useUserConfigCtx();
   const { groups, setter: setGroups } = useGroupCtx();
   const [loading, setLoading] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [membersModalOpen, setMembersModalOpen] = useState(false);
   const [newGroupName, setNewGroupName] = useState(group.name);
@@ -140,14 +157,27 @@ const GroupCard = ({
       return;
     }
 
-    const updatedGroups = groups.map((g) =>
-      g.account_id === group.account_id
-        ? { ...g, name: newGroupName, updated_at: new Date().toISOString() }
-        : g,
-    );
-    setGroups(updatedGroups, userData?.user_id);
-    alert('群組名稱已更新');
-    setEditModalOpen(false);
+    setIsEditing(true);
+    try {
+      const updatedGroup = {
+        ...group,
+        name: newGroupName.trim(),
+        updated_at: new Date().toISOString(),
+      };
+      const result = await putGroup(updatedGroup);
+      if (!result.status) {
+        alert(result.message || '更新失敗，請稍後再試');
+        return;
+      }
+      const updatedGroups = groups.map((g) =>
+        g.account_id === group.account_id ? updatedGroup : g,
+      );
+      setGroups(updatedGroups, userData?.user_id);
+      alert('群組名稱已更新');
+      setEditModalOpen(false);
+    } finally {
+      setIsEditing(false);
+    }
   };
 
   const handleRemoveMember = async (userId: number, userName: string) => {
@@ -200,7 +230,11 @@ const GroupCard = ({
         if (confirmDelete) {
           setLoading(true);
           try {
-            await deleteGroup(String(group.account_id));
+            const result = await deleteGroup(String(group.account_id));
+            if (!result.status) {
+              alert(result.message || '刪除失敗，請稍後再試');
+              return;
+            }
             const filteredGroups = groups.filter(
               (g) => g.account_id !== group.account_id,
             );
@@ -420,10 +454,10 @@ const GroupCard = ({
               <button
                 type="button"
                 onClick={handleEditGroupName}
-                disabled={loading}
+                disabled={isEditing || loading}
                 className="btn-primary min-h-11 px-4 disabled:cursor-not-allowed disabled:opacity-50"
               >
-                {loading ? '更新中...' : '確定'}
+                {isEditing ? '更新中...' : '確定'}
               </button>
             </div>
           </div>

--- a/my-app/src/services/groupServices.ts
+++ b/my-app/src/services/groupServices.ts
@@ -1,46 +1,60 @@
 const URL = '/api/aurora/groups';
 
-export const createGroup = async (data: Group) => {
+export const createGroup = async (
+  data: Group,
+): Promise<{ status: boolean; data?: Group; message: string }> => {
   try {
-    await fetch(URL, {
+    const res = await fetch(URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(data),
     });
-    return { status: true, message: 'success' };
+    const body = await res.json();
+    if (!res.ok || !body?.account_id) {
+      return { status: false, message: body?.message ?? '建立失敗' };
+    }
+    return { status: true, data: body as Group, message: 'success' };
   } catch (error) {
     console.error(error);
-    return { status: false, data: [], message: '發生不預期的錯誤' };
+    return { status: false, message: '發生不預期的錯誤' };
   }
 };
 
-export const putGroup = async (data: Group) => {
+export const putGroup = async (data: Group): Promise<{ status: boolean; message: string }> => {
   try {
-    await fetch(URL, {
+    const res = await fetch(URL, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(data),
     });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { status: false, message: body?.message ?? '更新失敗' };
+    }
     return { status: true, message: 'success' };
   } catch (error) {
     console.error(error);
-    return { status: false, data: [], message: '發生不預期的錯誤' };
+    return { status: false, message: '發生不預期的錯誤' };
   }
 };
 
-export const deleteGroup = async (id: string) => {
+export const deleteGroup = async (id: string): Promise<{ status: boolean; message: string }> => {
   try {
-    await fetch(`${URL}?id=${id}`, {
+    const res = await fetch(`${URL}?id=${id}`, {
       method: 'DELETE',
     });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      return { status: false, message: body?.message ?? '刪除失敗' };
+    }
     return { status: true, message: 'success' };
   } catch (error) {
     console.error(error);
-    return { status: false, data: [], message: '發生不預期的錯誤' };
+    return { status: false, message: '發生不預期的錯誤' };
   }
 };
 


### PR DESCRIPTION
handleCreateGroup and handleEditGroupName were only updating local state (setGroups) without calling the API, causing newly created or renamed ledgers to disappear after page reload. Also fix deleteGroup to check API result before updating state.

- Call createGroup API on creation; use server-returned group to update state
- Call putGroup API on name edit; await success before closing modal
- Check deleteGroup result status before removing from local state
- Add isCreating/isEditing loading guards to prevent double-submit
- Fix groups/route.ts catch blocks to return HTTP 500 so res.ok works
- Update createGroup/putGroup/deleteGroup services to read response status
- Remove unused RefreshIcon import, syncUser and loading destructures